### PR TITLE
client: correctly detect MIME

### DIFF
--- a/pyodata/client.py
+++ b/pyodata/client.py
@@ -37,7 +37,7 @@ class Client:
                     'Metadata request failed, status code: {}, body:\n{}'.format(resp.status_code, resp.content), resp)
 
             mime_type = resp.headers['content-type']
-            if mime_type not in ['application/xml', 'text/xml']:
+            if not any((typ in  ['application/xml', 'text/xml'] for typ in mime_type.split(';'))):
                 raise HttpError(
                     'Metadata request did not return XML, MIME type: {}, body:\n{}'.format(mime_type, resp.content),
                     resp)


### PR DESCRIPTION
I didn't expect that metadata will be sent in anything else that ASCII.
But we absolutely need to know the charset because of labels.

Northwind returns "Content-Type: application/xml;charset=utf-8"

Closes #7