### PR TITLE
Add implementation of count

### DIFF
--- a/USAGE.md
+++ b/USAGE.md
@@ -17,7 +17,7 @@ client = pyodata.Client(SERVICE_URL, requests.Session())
 ```python
 # Get employee identified by 1 and print employee first name
 employee1 = client.entity_sets.Employees.get_entity(1).execute()
-print employee1.FirstName
+print(employee1.FirstName)
 ```
 
 ### Get one entity identified by its key value which is not scalar
@@ -33,7 +33,7 @@ print(order.Quantity)
 ```python
 
 # Print unique identification (Id) and last name of all cemployees
-employees = client.entity_sets.Employees.get_entities().select('EmployeeID,LasttName').execute()
+employees = client.entity_sets.Employees.get_entities().select('EmployeeID,LastName').execute()
 for employee in employees:
     print(employee.EmployeeID, employee.LastName)
 ```
@@ -60,6 +60,22 @@ smith_employees_request = smith_employees_request.filter(GetEntitySetFilter.and_
                                                          smith_employees_request.LastName == 'Smith'))
 for smith in smith_employees_request.execute():
     print(smith.EmployeeID)
+```
+
+### Get a count of entities
+
+```python
+# Print a count of all employees
+count = client.entity_sets.Employees.get_entities().count().execute()
+print(count)
+```
+
+### Get a count of entities via navigation property
+
+```python
+# Print a count of all orders associated with Employee 1
+count = client.entity_sets.Employees.get_entity(1).nav('Orders').get_entities().count().execute()
+print(count)
 ```
 
 ### Creating entity

--- a/pyodata/client.py
+++ b/pyodata/client.py
@@ -37,7 +37,7 @@ class Client:
                     'Metadata request failed, status code: {}, body:\n{}'.format(resp.status_code, resp.content), resp)
 
             mime_type = resp.headers['content-type']
-            if not any((typ in  ['application/xml', 'text/xml'] for typ in mime_type.split(';'))):
+            if not any((typ in ['application/xml', 'text/xml'] for typ in mime_type.split(';'))):
                 raise HttpError(
                     'Metadata request did not return XML, MIME type: {}, body:\n{}'.format(mime_type, resp.content),
                     resp)

--- a/pyodata/v2/model.py
+++ b/pyodata/v2/model.py
@@ -659,7 +659,9 @@ class Schema:
     def entity_set(self, set_name, namespace=None):
         if namespace is not None:
             try:
-                return self._decls[namespace].entity_sets[set_name]
+                entity_sets = self._decls[namespace].entity_sets
+                if entity_sets:
+                    return entity_sets[set_name]
             except KeyError:
                 raise KeyError('EntitySet {} does not exist in Schema Namespace {}'.format(set_name, namespace))
 
@@ -722,14 +724,16 @@ class Schema:
 
     def association_set_by_association(self, association_name, namespace=None):
         if namespace is not None:
-            for association_set in list(self._decls[namespace].association_sets.values()):
+            association_sets = list(self._decls[namespace].association_sets.values())
+            for association_set in association_sets:
                 if association_set.association_type.name == association_name:
                     return association_set
-            raise KeyError('Association set with association type {} does not exist in namespace {}'.format(
-                association_name, namespace))
+            if association_sets:
+                raise KeyError('Association set with association type {} does not exist in namespace {}'.format(
+                    association_name, namespace))
         for decl in list(self._decls.values()):
             for association_set in list(decl.association_sets.values()):
-                if association_set.association_type == association_name:
+                if association_set.association_type_name == association_name:
                     return association_set
         raise KeyError('Association set with association type {} does not exist'.format(association_name))
 

--- a/tests/test_service_v2.py
+++ b/tests/test_service_v2.py
@@ -1046,3 +1046,81 @@ def test_get_entity_set_query_filter_property_error(service):
     with pytest.raises(KeyError) as e_info:
         assert not request.Foo == 'bar'
     assert e_info.value.args[0] == 'Foo'
+
+
+@responses.activate
+def test_count(service):
+    """Check getting $count"""
+
+    # pylint: disable=redefined-outer-name
+
+    responses.add(
+        responses.GET,
+        "{0}/Employees/$count".format(service.url),
+        json=23,
+        status=200)
+
+    request = service.entity_sets.Employees.get_entities().count()
+
+    assert isinstance(request, pyodata.v2.service.GetEntitySetRequest)
+
+    assert request.execute() == 23
+
+
+@responses.activate
+def test_count_with_skip(service):
+    """Check getting $count with $skip"""
+
+    # pylint: disable=redefined-outer-name
+
+    responses.add(
+        responses.GET,
+        "{0}/Employees/$count?$skip=12".format(service.url),
+        json=11,
+        status=200)
+
+    request = service.entity_sets.Employees.get_entities().skip(12).count()
+
+    assert isinstance(request, pyodata.v2.service.GetEntitySetRequest)
+
+    assert request.execute() == 11
+
+
+@responses.activate
+def test_navigation_count(service):
+    """Check getting $count via navigation property"""
+
+    # pylint: disable=redefined-outer-name
+
+    responses.add(
+        responses.GET,
+        "{0}/Employees(23)/Addresses/$count".format(service.url),
+        json=458,
+        status=200)
+
+    addresses = service.entity_sets.Employees.get_entity(23).nav('Addresses').get_entities()
+    request = addresses.count()
+
+    assert isinstance(request, pyodata.v2.service.GetEntitySetRequest)
+
+    assert request.execute() == 458
+
+
+@responses.activate
+def test_navigation_count_with_filter(service):
+    """Check getting $count via navigation property with $filter"""
+
+    # pylint: disable=redefined-outer-name
+
+    responses.add(
+        responses.GET,
+        "{0}/Employees(23)/Addresses/$count?$filter=City eq 'London'".format(service.url),
+        json=3,
+        status=200)
+
+    addresses = service.entity_sets.Employees.get_entity(23).nav('Addresses').get_entities()
+    request = addresses.filter(addresses.City == 'London').count()
+
+    assert isinstance(request, pyodata.v2.service.GetEntitySetRequest)
+
+    assert request.execute() == 3


### PR DESCRIPTION
Added:
* Implementation of the system query option `$count`
* Tests for `$count`, `$count` via navigation property, `$count` with `$filter` and `$skip` options
* Some examples for `$count` in the [USAGE](https://github.com/SAP/python-pyodata/compare/master...FedorSelitsky:count?expand=1#diff-0f23af2f696313fe32c17a0c7281cb57R65) section

Modified:
* Added checks that `entity_sets` and `assotiation_sets` for namespace are not empty in Schema's `entity_set` and `association_set_by_association` methods (because I got a `KeyError`, although the required values ​​were in `self._decls.values()`)
* `association_set.association_type` was replaced by `association_set.association_type_name` in the equality comparison with `association_name` in the Schema's `association_set_by_association` method (because I received a comparison: for example, `Association(FK_Orders_Customers)` with `FK_Orders_Customers` and finally got a `KeyError`)

Fixed:
* Removed [multiple spaces](https://github.com/SAP/python-pyodata/compare/master...FedorSelitsky:count?expand=1#diff-0199e5accaf7e63461c77e050ff7e764L40) in the Client's `__new__` method (because I received `odata/client.py:40:31: E271 multiple spaces after keyword` error when I runned `make check` command)
* Some typos in the [USAGE](https://github.com/SAP/python-pyodata/compare/master...FedorSelitsky:count?expand=1#diff-0f23af2f696313fe32c17a0c7281cb57L20) section and [docstrings](https://github.com/SAP/python-pyodata/compare/master...FedorSelitsky:count?expand=1#diff-a78bb250032d6016556ea423e462557fL324)

I will be happy to receive recommendations and suggestions from you.