### PR TITLE
Handle association set ends with same entity sets

### DIFF
--- a/pyodata/v2/service.py
+++ b/pyodata/v2/service.py
@@ -1002,7 +1002,8 @@ class EntitySetProxy:
                 navigation_entity_set = self._service.schema.entity_set(end.entity_set_name)
 
         if not navigation_entity_set:
-            raise PyODataException('No association set for role {} {}'.format(navigation_property.to_role, association_set.end_roles))
+            raise PyODataException(
+                'No association set for role {} {}'.format(navigation_property.to_role, association_set.end_roles))
 
         roles = navigation_property.association.end_roles
         if all((role.multiplicity != model.EndRole.MULTIPLICITY_ZERO_OR_MORE for role in roles)):

--- a/pyodata/v2/service.py
+++ b/pyodata/v2/service.py
@@ -789,9 +789,9 @@ class EntityProxy:
             association_info.namespace)
 
         navigation_entity_set = None
-        for entity_set in association_set.end_roles:
-            if association_set.end_roles[entity_set] == navigation_property.to_role.role:
-                navigation_entity_set = self._service.schema.entity_set(entity_set, association_info.namespace)
+        for end in association_set.end_roles:
+            if association_set.end_by_entity_set(end.entity_set_name).role == navigation_property.to_role.role:
+                navigation_entity_set = self._service.schema.entity_set(end.entity_set_name, association_info.namespace)
 
         if not navigation_entity_set:
             raise PyODataException('No association set for role {}'.format(navigation_property.to_role))
@@ -997,12 +997,12 @@ class EntitySetProxy:
             association_info.name)
 
         navigation_entity_set = None
-        for entity_set in association_set.end_roles:
-            if association_set.end_roles[entity_set] == navigation_property.to_role.role:
-                navigation_entity_set = self._service.schema.entity_set(entity_set)
+        for end in association_set.end_roles:
+            if association_set.end_by_entity_set(end.entity_set_name).role == navigation_property.to_role.role:
+                navigation_entity_set = self._service.schema.entity_set(end.entity_set_name)
 
         if not navigation_entity_set:
-            raise PyODataException('No association set for role {}'.format(navigation_property.to_role))
+            raise PyODataException('No association set for role {} {}'.format(navigation_property.to_role, association_set.end_roles))
 
         roles = navigation_property.association.end_roles
         if all((role.multiplicity != model.EndRole.MULTIPLICITY_ZERO_OR_MORE for role in roles)):

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -128,7 +128,6 @@ def metadata():
              </Dependent>
             </ReferentialConstraint>
            </Association>
-
            <Association Name="CustomerOrders">
             <End Role="CustomerRole" Type="EXAMPLE_SRV.Customer" Multiplicity="1"/>
             <End Role="OrdersRole" Type="EXAMPLE_SRV.Order" Multiplicity="*"/>
@@ -141,7 +140,10 @@ def metadata():
              </Dependent>
             </ReferentialConstraint>
            </Association>
-
+           <Association Name="toSelfMaster" sap:content-version="1">
+            <End Type="EXAMPLE_SRV.MasterEntity" Multiplicity="1" Role="FromRole_toSelfMaster" />
+            <End Type="EXAMPLE_SRV.MasterEntity" Multiplicity="0..1" Role="ToRole_toSelfMaster" />
+           </Association>
            <EntityContainer Name="EXAMPLE_SRV" m:IsDefaultEntityContainer="true" sap:supported-formats="atom json xlsx">
             <EntitySet Name="MasterEntities" EntityType="EXAMPLE_SRV.MasterEntity" sap:label="Master entities" sap:creatable="false" sap:updatable="false" sap:deletable="false" sap:searchable="true" sap:content-version="1"/>
             <EntitySet Name="DataValueHelp" EntityType="EXAMPLE_SRV.DataEntity" sap:creatable="false" sap:updatable="false" sap:deletable="false" sap:searchable="true" sap:content-version="1"/>
@@ -160,6 +162,10 @@ def metadata():
             <AssociationSet Name="toCarIDPicSet" Association="EXAMPLE_SRV.toCarIDPic" sap:creatable="false" sap:updatable="false" sap:deletable="false" sap:content-version="1">
               <End EntitySet="Cars" Role="FromRole_toCarIDPic" />
               <End EntitySet="CarIDPics" Role="ToRole_toCarIDPic" />
+            </AssociationSet>
+            <AssociationSet Name="toSelfMasterSet" Association="EXAMPLE_SRV.toSelfMaster" sap:creatable="false" sap:updatable="false" sap:deletable="false" sap:content-version="1">
+              <End EntitySet="MasterEntities" Role="FromRole_toSelfMaster" />
+              <End EntitySet="MasterEntities" Role="ToRole_toSelfMaster" />
             </AssociationSet>
            </EntityContainer>
            <Annotations xmlns="http://docs.oasis-open.org/odata/ns/edm" Target="EXAMPLE_SRV.MasterEntity/Data">


### PR DESCRIPTION
In the metadata document, it is allowed to declare same Entity Sets in
different ends of one Association Set. Therefore, we cannot utilize
dictionary to store such ends (values can be overwritten).

In this commit, there is added a new class AssociationSetEndRole which
represents one end within the Association Set. End roles are stored in
a list, in the same manner like end roles in the Association. Also,
each end now contains a reference to a corresponding entity set.