### PR TITLE
setup.py - add long_description_content_type

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -36,6 +36,7 @@ setup(
     author_email="jakub.filak@sap.com, michal.nezerka@sap.com, patrik.petrik@sap.com, lubos.mjachky@sap.com",
     description="Enterprise ready Python OData client",
     long_description=_read('README.md'),
+    long_description_content_type="text/markdown",
     packages=find_packages(exclude=("tests")),
     zip_safe=False,
     install_requires=[


### PR DESCRIPTION
pypi now reject other then .rst description without specifying content type. 
More info: https://pypi.org/help/#description-content-type