### PR TITLE
model: fix parsing of Edm.Int64 values

### DIFF
--- a/pyodata/v2/model.py
+++ b/pyodata/v2/model.py
@@ -192,7 +192,7 @@ class Types:
                 Typ('Edm.Guid', 'guid\'00000000-0000-0000-0000-000000000000\'', EdmPrefixedTypTraits('guid')))
             Types.register_type(Typ('Edm.Int16', '0', EdmIntTypTraits()))
             Types.register_type(Typ('Edm.Int32', '0', EdmIntTypTraits()))
-            Types.register_type(Typ('Edm.Int64', '0L', EdmIntTypTraits()))
+            Types.register_type(Typ('Edm.Int64', '0L', EdmLongIntTypTraits()))
             Types.register_type(Typ('Edm.SByte', '0'))
             Types.register_type(Typ('Edm.String', '\'\'', EdmStringTypTraits()))
             Types.register_type(Typ('Edm.Time', 'time\'PT00H00M\''))
@@ -459,6 +459,24 @@ class EdmIntTypTraits(TypTraits):
 
     def from_literal(self, value):
         return int(value)
+
+
+class EdmLongIntTypTraits(TypTraits):
+    """All Edm Integer for big numbers traits"""
+
+    # pylint: disable=no-self-use
+    def to_literal(self, value):
+        return '%dL' % (value)
+
+    # pylint: disable=no-self-use
+    def from_json(self, value):
+        if value[-1] == 'L':
+            return int(value[:-1])
+
+        return int(value)
+
+    def from_literal(self, value):
+        return self.from_json(value)
 
 
 class EdmStructTypTraits(TypTraits):

--- a/tests/test_model_v2.py
+++ b/tests/test_model_v2.py
@@ -382,9 +382,16 @@ def test_traits():
     assert typ.traits.from_literal('345') == 345
 
     typ = Types.from_name('Edm.Int64')
-    assert repr(typ.traits) == 'EdmIntTypTraits'
-    assert typ.traits.to_literal(23) == '23'
+    assert repr(typ.traits) == 'EdmLongIntTypTraits'
+    assert typ.traits.to_literal(23) == '23L'
+    assert typ.traits.from_literal('345L') == 345
+    assert typ.traits.from_json('345L') == 345
     assert typ.traits.from_literal('345') == 345
+    assert typ.traits.from_json('345') == 345
+    assert typ.traits.from_literal('0') == 0
+    assert typ.traits.from_json('0') == 0
+    assert typ.traits.from_literal('0L') == 0
+    assert typ.traits.from_json('0L') == 0
 
     # GUIDs
     typ = Types.from_name('Edm.Guid')


### PR DESCRIPTION
Edm.Int64 should have the suffix L
SucessFactors services return some values without the suffix L