### PR TITLE
No return type functions

### DIFF
--- a/pyodata/v2/model.py
+++ b/pyodata/v2/model.py
@@ -1108,7 +1108,8 @@ class Schema:
                 efn = FunctionImport.from_etree(function_import, config)
 
                 # complete type information for return type and parameters
-                efn.return_type = schema.get_type(efn.return_type_info)
+                if efn.return_type_info is not None:
+                    efn.return_type = schema.get_type(efn.return_type_info)
                 for param in efn.parameters:
                     param.typ = schema.get_type(param.type_info)
                 decl.function_imports[efn.name] = efn
@@ -2321,7 +2322,10 @@ class FunctionImport(Identifier):
         name = function_import_node.get('Name')
         entity_set = function_import_node.get('EntitySet')
         http_method = metadata_attribute_get(function_import_node, 'HttpMethod')
-        rt_info = Types.parse_type_name(function_import_node.get('ReturnType'))
+
+        rt_type = function_import_node.get('ReturnType')
+        rt_info = None if rt_type is None else Types.parse_type_name(rt_type)
+        print(name, rt_type, rt_info)
 
         parameters = dict()
         for param in function_import_node.xpath('edm:Parameter', namespaces=config.namespaces):

--- a/pyodata/v2/model.py
+++ b/pyodata/v2/model.py
@@ -800,7 +800,7 @@ class Schema:
     def get_type(self, type_info):
 
         # construct search name based on collection information
-        search_name = type_info[1] if not type_info[2] else 'Collection({})'.format(type_info[1])
+        search_name = type_info.name if not type_info.is_collection else 'Collection({})'.format(type_info.name)
 
         # first look for type in primitive types
         try:
@@ -810,25 +810,25 @@ class Schema:
 
         # then look for type in entity types
         try:
-            return self.entity_type(search_name, type_info[0])
+            return self.entity_type(search_name, type_info.namespace)
         except KeyError:
             pass
 
         # then look for type in complex types
         try:
-            return self.complex_type(search_name, type_info[0])
+            return self.complex_type(search_name, type_info.namespace)
         except KeyError:
             pass
 
         # then look for type in enum types
         try:
-            return self.enum_type(search_name, type_info[0])
+            return self.enum_type(search_name, type_info.namespace)
         except KeyError:
             pass
 
         raise PyODataModelError(
-            'Neither primitive types nor types parsed from service metadata contain requested type {}'.format(type_info[
-                1]))
+            'Neither primitive types nor types parsed from service metadata contain requested type {}'
+            .format(type_info.name))
 
     @property
     def entity_types(self):
@@ -1019,7 +1019,7 @@ class Schema:
                         prop.typ = schema.get_type(prop.type_info)
                     except PyODataModelError as ex:
                         config.err_policy(ParserError.PROPERTY).resolve(ex)
-                        prop.typ = NullType(prop.type_info[1])
+                        prop.typ = NullType(prop.type_info.name)
 
         # pylint: disable=too-many-nested-blocks
         # Then, process Associations nodes because they refer EntityTypes and

--- a/pyodata/v2/service.py
+++ b/pyodata/v2/service.py
@@ -1177,9 +1177,16 @@ class FunctionContainer:
         def function_import_handler(fimport, response):
             """Get function call response from HTTP Response"""
 
-            if response.status_code != requests.codes.ok:
-                raise HttpError('Function import call failed with status code {0}'.format(response.status_code),
+            if response.status_code >= 300:
+                raise HttpError('Function import call failed with the status code {0}'.format(response.status_code),
                                 response)
+
+            if fimport.return_type is None:
+                if response.text:
+                    logging.getLogger(LOGGER_NAME).warning(
+                        'The No Return Function import has returned content:\n%s', response.text)
+
+                return None
 
             response_data = response.json()['d']
 

--- a/tests/metadata.xml
+++ b/tests/metadata.xml
@@ -206,6 +206,7 @@
                                 sap:action-for="EXAMPLE_SRV.MasterEntity">
                     <Parameter Name="Param" Type="Edm.String" Mode="In" MaxLenght="5"/>
                 </FunctionImport>
+                <FunctionImport Name="refresh" m:HttpMethod="GET"/>
                 <AssociationSet Name="toDataEntitySet" Association="EXAMPLE_SRV.toDataEntity" sap:creatable="false"
                                 sap:updatable="false" sap:deletable="false" sap:content-version="1">
                     <End EntitySet="MasterEntities" Role="FromRole_toDataEntity"/>

--- a/tests/test_model_v2.py
+++ b/tests/test_model_v2.py
@@ -268,7 +268,7 @@ def test_edmx_function_imports(schema):
     """Test parsing of function imports"""
 
     assert set((func_import.name for func_import in schema.function_imports)) == {'get_best_measurements', 'retrieve',
-                                                                                  'get_max', 'sum', 'sum_complex'}
+                                                                                  'get_max', 'sum', 'sum_complex', 'refresh'}
     # pylint: disable=redefined-outer-name
 
     function_import = schema.function_import('retrieve')
@@ -287,6 +287,11 @@ def test_edmx_function_imports(schema):
     assert param.mode == 'In'
     assert param.typ.traits.to_literal('Foo') == "'Foo'"
     assert param.typ.traits.from_literal("'Foo'") == 'Foo'
+
+    # function import without return type
+    function_import = schema.function_import('refresh')
+    assert function_import.return_type is None
+    assert function_import.http_method == 'GET'
 
     # function import that returns entity
     function_import = schema.function_import('get_max')

--- a/tests/test_service_v2.py
+++ b/tests/test_service_v2.py
@@ -362,6 +362,21 @@ def test_function_import_primitive(service):
 
 
 @responses.activate
+def test_function_import_without_return_type(service):
+    """A simple function call without return type"""
+
+    # pylint: disable=redefined-outer-name
+
+    responses.add(
+        responses.GET,
+        "{0}/refresh".format(service.url),
+        status=204)
+
+    result = service.functions.refresh.execute()
+    assert result is None
+
+
+@responses.activate
 def test_function_import_entity(service):
     """Function call with entity return type"""
 


### PR DESCRIPTION
OData V2 FunctionImports do no have to have ReturnType defined:
https://help.sap.com/viewer/u_collaboration_dev_help/dacad2174f654e62a75754d71fee9da2.html#loiodacad2174f654e62a75754d71fee9da2__FunctionImport