### PR TITLE
small typo fix in tests

### DIFF
--- a/tests/test_model_v2.py
+++ b/tests/test_model_v2.py
@@ -744,6 +744,7 @@ def test_annot_v_l_trgt_inv_prop(mock_warning, mock_resolve, xml_builder_factory
 
     metadata.build()
     assert PolicyIgnore.resolve is mock_resolve
+
     mock_resolve.assert_called_once()
 
     metadata.config.set_custom_error_policy({

--- a/tests/test_model_v2.py
+++ b/tests/test_model_v2.py
@@ -744,7 +744,6 @@ def test_annot_v_l_trgt_inv_prop(mock_warning, mock_resolve, xml_builder_factory
 
     metadata.build()
     assert PolicyIgnore.resolve is mock_resolve
-
     mock_resolve.assert_called_once()
 
     metadata.config.set_custom_error_policy({

--- a/tests/test_model_v2.py
+++ b/tests/test_model_v2.py
@@ -744,7 +744,7 @@ def test_annot_v_l_trgt_inv_prop(mock_warning, mock_resolve, xml_builder_factory
 
     metadata.build()
     assert PolicyIgnore.resolve is mock_resolve
-    mock_resolve.asser_called_once()
+    mock_resolve.assert_called_once()
 
     metadata.config.set_custom_error_policy({
         ParserError.ANNOTATION: PolicyWarning()


### PR DESCRIPTION
There is a small typo in tests, asserT_called_once instead of asser_called_once