### PR TITLE
Enhance the pyodata executable to parse local metadata and specify policies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
+### Added
+- Client can be created from local metadata - Jakub Filak
+
 ## [1.3.0]
 
 ### Added

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,10 @@
 PYTHON_MODULE=pyodata
+PYTHON_BINARIES=
+PYTHON_MODULE_FILES=$(shell find $(PYTHON_MODULE) -type f -name '*.py')
+
+TESTS_DIR=tests
+TESTS_UNIT_DIR=$(TESTS_DIR)
+TESTS_UNIT_FILES=$(shell find $(TESTS_UNIT_DIR) -type f -name '*.py')
 
 PYTHON_BIN=python3
 
@@ -13,6 +19,13 @@ FLAKE8_BIN=flake8
 FLAKE8_CONFIG_FILE=.flake8
 FLAKE8_PARAMS=
 
+COVERAGE_BIN=coverage3
+COVERAGE_REPORT_ARGS=--skip-covered
+COVERAGE_CMD_HTML=$(COVERAGE_BIN) html
+COVERAGE_HTML_DIR=.htmlcov
+COVERAGE_HTML_ARGS=$(COVERAGE_REPORT_ARGS) -d $(COVERAGE_HTML_DIR)
+COVERAGE_REPORT_FILES=$(PYTHON_BINARIES) $(PYTHON_MODULE_FILES)
+
 all: check
 
 .PHONY=check
@@ -24,6 +37,15 @@ lint: doc
 test:
 	$(PYTHON_BIN) -m $(PYTEST_MODULE) $(PYTEST_PARAMS)
 
+.coverage: $(COVERAGE_REPORT_FILES) $(TESTS_UNIT_FILES)
+	$(MAKE) test PYTEST_PARAMS="--cov-report= --cov=$(PYTHON_MODULE)"
+
+.PHONY: report-coverage-html
+report-coverage-html: .coverage
+	@ echo "Generating HTML code coverage report ..."
+	@ $(COVERAGE_CMD_HTML) $(COVERAGE_HTML_ARGS) $(COVERAGE_REPORT_FILES)
+	@ echo "Report: file://$$(pwd)/$(COVERAGE_HTML_DIR)/index.html"
+
 .PHONY=check
 check: lint test
 
@@ -31,3 +53,7 @@ check: lint test
 doc:
 	$(MAKE) -C docs html
 	@ echo -e "\nOpen: file://$$(pwd)/docs/_build/html/index.html"
+
+.PHONY=clean
+clean:
+	rm --preserve-root -rf $(COVERAGE_HTML_DIR) .coverage

--- a/bin/pyodata
+++ b/bin/pyodata
@@ -4,9 +4,27 @@ import sys
 from argparse import ArgumentParser
 
 import pyodata
+from pyodata.v2.model import PolicyFatal, PolicyWarning, PolicyIgnore, ParserError, Config
+
 import requests
 
 from getpass import getpass
+
+
+ERROR_POLICIES={
+    'FATAL': PolicyFatal,
+    'WARNING': PolicyWarning,
+    'IGNORE': PolicyIgnore
+}
+
+POLICY_TARGETS={
+    'PARSER_INVALID_PROPERTY': ParserError.PROPERTY,
+    'PARSER_INVALID_ANNOTATION': ParserError.ANNOTATION,
+    'PARSER_INVALID_ASSOCIATION': ParserError.ASSOCIATION,
+    'PARSER_INVALID_ENUM_TYPE': ParserError.ENUM_TYPE,
+    'PARSER_INVALID_ENTITY_TYPE': ParserError.ENTITY_TYPE,
+    'PARSER_INVALID_COMPLEX_TYPE': ParserError.COMPLEX_TYPE
+}
 
 
 def print_out_metadata_info(args, client):
@@ -59,7 +77,6 @@ def print_out_function_import(args, client):
     response = function.execute()
     print(response)
 
-
 def _parse_args(argv):
     parser = ArgumentParser()
     parser.add_argument('SERVICE_ROOT_URL', type=str)
@@ -69,6 +86,11 @@ def _parse_args(argv):
                         help='Path to the XML file with service $metadata')
     parser.add_argument('--no-session-init', default=False,
                         action='store_true', help='Skip HTTP session initialization')
+    parser.add_argument('--default-error-policy', default=None, choices=ERROR_POLICIES.keys(),
+                        help='Specify metadata parser default error handler')
+    parser.add_argument('--custom-error-policy', action='append', type=str,
+                        help='Specify metadata parser custom error handlers in the form: TARGET=POLICY')
+
     parser.set_defaults(func=print_out_metadata_info)
 
     subparsers = parser.add_subparsers()
@@ -119,7 +141,38 @@ def _main(argv):
     else:
         print('[Fetching $metadata ...]')
 
-    client = pyodata.Client(args.SERVICE_ROOT_URL, session, metadata=static_metadata)
+    config = None
+
+    def get_config():
+        if config is None:
+            return Config()
+
+        return config
+
+    if args.default_error_policy:
+        config = get_config()
+        config.set_default_error_policy(ERROR_POLICIES[args.default_error_policy]())
+
+    if args.custom_error_policy:
+        custom_policies = dict()
+
+        try:
+            for target, policy in (param.split('=') for param in args.custom_error_policy):
+                try:
+                    custom_policies[POLICY_TARGETS[target]] = ERROR_POLICIES[policy]()
+                except KeyError as ex:
+                    print(f'Invalid Error Target ({target}) or Error Policy ({policy}): {str(ex)}', file=sys.stderr)
+                    print('Allowed targets : {}'.format(';'.join(POLICY_TARGETS.keys())), file=sys.stderr)
+                    print('Allowed policies: {}'.format(';'.join(ERROR_POLICIES.keys())), file=sys.stderr)
+                    sys.exit(1)
+        except ValueError as ex:
+            print('Custom policy must have the format TARGET=POLICY: {}'.format(' '.join(args.custom_error_policy)), file=sys.stderr)
+            sys.exit(1)
+
+        config = get_config()
+        config.set_custom_error_policy(custom_policies)
+
+    client = pyodata.Client(args.SERVICE_ROOT_URL, session, metadata=static_metadata, config=config)
 
     args.func(args, client)
 

--- a/bin/pyodata
+++ b/bin/pyodata
@@ -67,6 +67,8 @@ def _parse_args(argv):
     parser.add_argument('--password', default=None, type=str)
     parser.add_argument('--metadata', default=None, type=str,
                         help='Path to the XML file with service $metadata')
+    parser.add_argument('--no-session-init', default=False,
+                        action='store_true', help='Skip HTTP session initialization')
     parser.set_defaults(func=print_out_metadata_info)
 
     subparsers = parser.add_subparsers()
@@ -97,13 +99,17 @@ def _main(argv):
 
         session.auth = (args.user, args.password)
 
-    try:
-        session.head(args.SERVICE_ROOT_URL)
-        args.password = 'xxxxx'
-    except pyodata.exceptions.HttpError as err:
-        sys.stderr.write(str(err))
-        sys.stderr.write('\n')
-        sys.exit(1)
+    # Oh, I am sorry for the double negation,
+    # but I cannot find a better construction.
+    if args.no_session_init == False:
+        print('[Initializing HTTP session ...]')
+        try:
+            session.head(args.SERVICE_ROOT_URL)
+            args.password = 'xxxxx'
+        except pyodata.exceptions.HttpError as err:
+            sys.stderr.write(str(err))
+            sys.stderr.write('\n')
+            sys.exit(1)
 
     static_metadata = None
     if args.metadata:

--- a/bin/pyodata
+++ b/bin/pyodata
@@ -65,6 +65,8 @@ def _parse_args(argv):
     parser.add_argument('SERVICE_ROOT_URL', type=str)
     parser.add_argument('--user', default=None, type=str)
     parser.add_argument('--password', default=None, type=str)
+    parser.add_argument('--metadata', default=None, type=str,
+                        help='Path to the XML file with service $metadata')
     parser.set_defaults(func=print_out_metadata_info)
 
     subparsers = parser.add_subparsers()
@@ -103,8 +105,15 @@ def _main(argv):
         sys.stderr.write('\n')
         sys.exit(1)
 
-    print('[Fetching $metadata ...]')
-    client = pyodata.Client(args.SERVICE_ROOT_URL, session)
+    static_metadata = None
+    if args.metadata:
+        print(f'[Loading $metadata from: {args.metadata} ...]')
+        with open(args.metadata, 'rb') as mtd_fl:
+            static_metadata = mtd_fl.read()
+    else:
+        print('[Fetching $metadata ...]')
+
+    client = pyodata.Client(args.SERVICE_ROOT_URL, session, metadata=static_metadata)
 
     args.func(args, client)
 

--- a/docs/usage/initialization.rst
+++ b/docs/usage/initialization.rst
@@ -77,8 +77,28 @@ Python client initialization:
 
     client = pyodata.Client(SERVICE_URL, session)
 
-
 For more information on client side SSL cerificationcas, please refer to this [gist](https://gist.github.com/mtigas/952344).
+
+Get the service with local metadata
+-----------------------------------
+
+It may happen that you will have metadata document for your service downloaded
+in a local file and you will want to initialize the service proxy from this
+file. In such a case you can provide content of the file as the named argument
+`metadata`. Please, make sure you provide `bytes` and not `str` (required by
+the xml parser lxml).
+
+.. code-block:: python
+
+    import pyodata
+    import requests
+
+    SERVICE_URL = 'http://services.odata.org/V2/Northwind/Northwind.svc/'
+
+    with open('/the/file/path.xml', 'rb') as mtd_file:
+        local_metadata = mtd_file.read()
+
+    northwind = pyodata.Client(SERVICE_URL, requests.Session(), metadata=local_metadata)
 
 Dealing with errors during parsing metadata
 -------------------------------------------

--- a/pyodata/client.py
+++ b/pyodata/client.py
@@ -8,6 +8,28 @@ import pyodata.v2.service
 from pyodata.exceptions import PyODataException, HttpError
 
 
+def _fetch_metadata(connection, url, logger):
+    # download metadata
+    logger.info('Fetching metadata')
+    resp = connection.get(url + '$metadata')
+
+    logger.debug('Retrieved the response:\n%s\n%s',
+                 '\n'.join((f'H: {key}: {value}' for key, value in resp.headers.items())),
+                 resp.content)
+
+    if resp.status_code != 200:
+        raise HttpError(
+            'Metadata request failed, status code: {}, body:\n{}'.format(resp.status_code, resp.content), resp)
+
+    mime_type = resp.headers['content-type']
+    if not any((typ in ['application/xml', 'text/xml'] for typ in mime_type.split(';'))):
+        raise HttpError(
+            'Metadata request did not return XML, MIME type: {}, body:\n{}'.format(mime_type, resp.content),
+            resp)
+
+    return resp.content
+
+
 class Client:
     """OData service client"""
 
@@ -16,7 +38,7 @@ class Client:
     ODATA_VERSION_2 = 2
 
     def __new__(cls, url, connection, odata_version=ODATA_VERSION_2, namespaces=None,
-                config: pyodata.v2.model.Config = None):
+                config: pyodata.v2.model.Config = None, metadata: str = None):
         """Create instance of the OData Client for given URL"""
 
         logger = logging.getLogger('pyodata.client')
@@ -26,23 +48,10 @@ class Client:
             # sanitize url
             url = url.rstrip('/') + '/'
 
-            # download metadata
-            logger.info('Fetching metadata')
-            resp = connection.get(url + '$metadata')
-
-            logger.debug('Retrieved the response:\n%s\n%s',
-                         '\n'.join((f'H: {key}: {value}' for key, value in resp.headers.items())),
-                         resp.content)
-
-            if resp.status_code != 200:
-                raise HttpError(
-                    'Metadata request failed, status code: {}, body:\n{}'.format(resp.status_code, resp.content), resp)
-
-            mime_type = resp.headers['content-type']
-            if not any((typ in ['application/xml', 'text/xml'] for typ in mime_type.split(';'))):
-                raise HttpError(
-                    'Metadata request did not return XML, MIME type: {}, body:\n{}'.format(mime_type, resp.content),
-                    resp)
+            if metadata is None:
+                metadata = _fetch_metadata(connection, url, logger)
+            else:
+                logger.info('Using static metadata')
 
             if config is not None and namespaces is not None:
                 raise PyODataException('You cannot pass namespaces and config at the same time')
@@ -56,7 +65,7 @@ class Client:
 
             # create model instance from received metadata
             logger.info('Creating OData Schema (version: %d)', odata_version)
-            schema = pyodata.v2.model.MetadataBuilder(resp.content, config=config).build()
+            schema = pyodata.v2.model.MetadataBuilder(metadata, config=config).build()
 
             # create service instance based on model we have
             logger.info('Creating OData Service (version: %d)', odata_version)

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -23,6 +23,17 @@ def test_invalid_odata_version():
 
 
 @responses.activate
+def test_create_client_for_local_metadata(metadata):
+    """Check client creation for valid use case with local metadata"""
+
+    client = pyodata.Client(SERVICE_URL, requests, metadata=metadata)
+
+    assert isinstance(client, pyodata.v2.service.Service)
+
+    assert len(client.schema.entity_sets) != 0
+
+
+@responses.activate
 def test_create_service_application_xml(metadata):
     """Check client creation for valid use case with MIME type 'application/xml'"""
 


### PR DESCRIPTION
Every time we get an error report with metadata, we have to create a custom code to get the real error.

This PR should allow us to use the helper pyodata and avoid the need to write code.