### PR TITLE
model: implement floating point numbers handling

### DIFF
--- a/pyodata/v2/model.py
+++ b/pyodata/v2/model.py
@@ -186,8 +186,9 @@ class Types:
             Types.register_type(Typ('Edm.Byte', '0'))
             Types.register_type(Typ('Edm.DateTime', 'datetime\'2000-01-01T00:00\'', EdmDateTimeTypTraits()))
             Types.register_type(Typ('Edm.Decimal', '0.0M'))
-            Types.register_type(Typ('Edm.Double', '0.0d'))
-            Types.register_type(Typ('Edm.Single', '0.0f'))
+            Types.register_type(Typ('Edm.Double', '0.0d', EdmFPNumTypTraits.edm_double()))
+            Types.register_type(Typ('Edm.Single', '0.0f', EdmFPNumTypTraits.edm_single()))
+            Types.register_type(Typ('Edm.Float', '0.0d', EdmFPNumTypTraits.edm_float()))
             Types.register_type(
                 Typ('Edm.Guid', 'guid\'00000000-0000-0000-0000-000000000000\'', EdmPrefixedTypTraits('guid')))
             Types.register_type(Typ('Edm.Int16', '0', EdmIntTypTraits()))
@@ -486,6 +487,49 @@ class EdmLongIntTypTraits(TypTraits):
             return int(value[:-1])
 
         return int(value)
+
+    def from_literal(self, value):
+        return self.from_json(value)
+
+
+class EdmFPNumTypTraits(TypTraits):
+    """Edm Floating Point Number traits"""
+
+    def __init__(self, precision, suffix, conversion):
+        self.precision = precision
+        self.suffix = suffix
+        self.conversion = conversion
+
+    def __repr__(self):
+        parent = super(EdmFPNumTypTraits, self).__repr__()
+
+        return f'{parent}({self.precision},{self.suffix})'
+
+    @staticmethod
+    def edm_float():
+        return EdmFPNumTypTraits(7, 'd', '{:E}')
+
+    @staticmethod
+    def edm_double():
+        return EdmFPNumTypTraits(15, 'd', '{:E}')
+
+    @staticmethod
+    def edm_single():
+        return EdmFPNumTypTraits(7, 'f', '{:f}')
+
+    # pylint: disable=no-self-use
+    def to_literal(self, value):
+        return self.conversion.format(value)
+
+    def to_json(self, value):
+        return self.to_literal(value)
+
+    # pylint: disable=no-self-use
+    def from_json(self, value):
+        if not isinstance(value, str) or value[-1] != self.suffix:
+            return float(value)
+
+        return float(value[:-1])
 
     def from_literal(self, value):
         return self.from_json(value)

--- a/tests/test_model_v2.py
+++ b/tests/test_model_v2.py
@@ -398,6 +398,35 @@ def test_traits():
     assert typ.traits.from_literal('0L') == 0
     assert typ.traits.from_json('0L') == 0
 
+    typ = Types.from_name('Edm.Double')
+    assert repr(typ.traits) == 'EdmFPNumTypTraits(15,d)'
+    assert typ.traits.from_literal('1E+10d') == 10.0**10
+    assert typ.traits.from_literal('1E+10') == 10.0**10
+    assert typ.traits.from_literal('2.029d') == 2.029
+    assert typ.traits.from_literal('2.0d') == 2.0
+    assert typ.traits.from_json('2.0d') == 2.0
+    assert typ.traits.to_literal(10.0**10) == '1.000000E+10'
+    assert typ.traits.to_literal(2.029) == '2.029000E+00'
+    assert typ.traits.to_literal(2.0) == '2.000000E+00'
+    assert typ.traits.to_json(2.0) == '2.000000E+00'
+
+    typ = Types.from_name('Edm.Single')
+    assert repr(typ.traits) == 'EdmFPNumTypTraits(7,f)'
+    assert typ.traits.from_literal('2.029f') == 2.029
+    assert typ.traits.from_literal('2.029') == 2.029
+    assert typ.traits.from_json('2.029f') == 2.029
+    assert typ.traits.to_literal(2.029) == '2.029000'
+    assert typ.traits.to_json(2.029) == '2.029000'
+
+    typ = Types.from_name('Edm.Float')
+    assert repr(typ.traits) == 'EdmFPNumTypTraits(7,d)'
+    assert typ.traits.from_literal('2.029d') == 2.029
+    assert typ.traits.from_literal('2.029') == 2.029
+    assert typ.traits.from_json('2.029d') == 2.029
+    assert typ.traits.from_json('3.76000000E+04') == 3.76*10**4
+    assert typ.traits.to_literal(2.029) == '2.029000E+00'
+    assert typ.traits.to_json(2.029) == '2.029000E+00'
+
     # GUIDs
     typ = Types.from_name('Edm.Guid')
     assert repr(typ.traits) == 'EdmPrefixedTypTraits'

--- a/tests/test_service_v2.py
+++ b/tests/test_service_v2.py
@@ -556,7 +556,7 @@ def test_function_import_entity(service):
         json={'d': {
             'Sensor': 'Sensor-address',
             'Date': "/Date(1516614510000)/",
-            'Value': 456.8
+            'Value': '456.8d'
         }},
         status=200)
 
@@ -578,7 +578,7 @@ def test_update_entity(service):
         json={'d': {
             'Sensor': 'Sensor-address',
             'Date': "/Date(1714138400000)/",
-            'Value': 34
+            'Value': '34.0d'
         }},
         status=204)
 
@@ -588,11 +588,11 @@ def test_update_entity(service):
 
     assert isinstance(request, pyodata.v2.service.EntityModifyRequest)
 
-    request.set(Value=34)
+    request.set(Value=34.0)
     # Tests if update entity correctly calls 'to_json' method
     request.set(Date=datetime.datetime(2017, 12, 24, 19, 0))
 
-    assert request._values['Value'] == 34
+    assert request._values['Value'] == '3.400000E+01'
     assert request._values['Date'] == '/Date(1514142000000)/'
 
     # If preformatted datetime is passed (e. g. you already replaced datetime instance with string which is
@@ -1145,7 +1145,7 @@ def test_batch_request(service):
                      b'HTTP/1.1 204 Updated\n'
                      b'Content-Type: application/json\n'
                      b'\n'
-                     b"{b'd': {'Sensor': 'Sensor-address', 'Date': datetime\'2017-12-24T18:00\', 'Value': 34}}"
+                     b"{b'd': {'Sensor': 'Sensor-address', 'Date': datetime\'2017-12-24T18:00\', 'Value': '34.0d'}}"
                      b'\n'
                      b'--changeset_1--\n'
                      b'\n'
@@ -1166,7 +1166,7 @@ def test_batch_request(service):
 
     temp_request = service.entity_sets.TemperatureMeasurements.update_entity(
         Sensor='sensor1',
-        Date=datetime.datetime(2017, 12, 24, 18, 0)).set(Value=34)
+        Date=datetime.datetime(2017, 12, 24, 18, 0)).set(Value=34.0)
 
     batch.add_request(employee_request)
 
@@ -1465,7 +1465,7 @@ def test_create_entity_with_datetime(service):
         json={'d': {
             'Sensor': 'Sensor1',
             'Date': '/Date(1514138400000)/',
-            'Value': '34'
+            'Value': '34.0d'
         }},
         status=201)
 
@@ -1474,7 +1474,7 @@ def test_create_entity_with_datetime(service):
     request = service.entity_sets.TemperatureMeasurements.create_entity().set(**{
         'Sensor': 'Sensor1',
         'Date': datetime.datetime(2017, 12, 24, 18, 0, tzinfo=MyUTCOffsetTimezone(-18000)),
-        'Value': 34
+        'Value': 34.0
     })
 
     assert request._values['Date'] == '/Date(1514138400000)/'
@@ -1496,14 +1496,14 @@ def test_parsing_of_datetime_before_unix_time(service):
         json={'d': {
             'Sensor': 'Sensor1',
             'Date': '/Date(-777877200000)/',
-            'Value': '34'
+            'Value': '34.0d'
         }},
         status=201)
 
     request = service.entity_sets.TemperatureMeasurements.create_entity().set(**{
         'Sensor': 'Sensor1',
         'Date': datetime.datetime(1945, 5, 8, 19, 0),
-        'Value': 34
+        'Value': 34.0
     })
 
     assert request._values['Date'] == '/Date(-777877200000)/'


### PR DESCRIPTION
It turned out that PyOData does not understand floating point numbers as
defined in OData standards.

This commit adds special formatters and parsers for floating point
numbers as represented in OData standards.

The commit also adds the type Edm.Float which is not defined in
the OData V2 standard but it is most probably of a new created
Edm format specification.

The OData standard is kinda fuzzy and even examples do not match
the requirements. Hence, do not be confused by the fact that we do not
add the suffixes {d,f} to string representations and we don't check if
converted literals have the suffix.

Closes #81