### PR TITLE
bump requests to 2.23 and move to install_require

### DIFF
--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -1,4 +1,4 @@
-requests==2.20.0
+requests==2.23.0
 pytest>=2.7.0
 responses>=0.8.1
 setuptools>=38.2.4

--- a/docs/usage/querying.rst
+++ b/docs/usage/querying.rst
@@ -86,3 +86,15 @@ Print a count of all orders associated with Employee 1:
 
     count = northwind.entity_sets.Employees.get_entity(1).nav('Orders').get_entities().count().execute()
     print(count)
+
+
+Use non-standard OData URL Query parameters
+-------------------------------------------
+
+Sometimes services implement extension to OData model and require addition URL
+query parameters. In such a case, you can enrich HTTP request made by pyodata with
+these parameters by the method `custom(name: str, value: str)`.
+
+.. code-block:: python
+
+    employee = northwind.entity_sets.Employees.get_entity(1).custom('sap-client', '100').execute()

--- a/setup.py
+++ b/setup.py
@@ -46,7 +46,7 @@ setup(
         "flake8",
         "setuptools>=38.2.4",
         "setuptools-scm>=1.15.6",
-        "requests==2.20.0",
+        "requests==2.23.0",
         "responses>=0.8.1",
         "pylint",
         "pytest>=2.7.0",


### PR DESCRIPTION
This PR addresses two issues:

1. Pinned usage of two year old version of Requests lib - update from 2.20 to 2.23

2. Move of this dependency to install_requires/requriments.txt from tests_require/dev-requirements.txt

Reason: while mainly used in tests, requests package is imported and used in service.py as well. e.g.   https://github.com/SAP/python-pyodata/blob/8937eca8a36aa49b5dc34e2b8de08a7671b69ccc/pyodata/v2/service.py#L840


