### PR TITLE
Replace python builtin exceptions with custom ones

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ### Added
 - support for Edm.Float - Jakub Filak
 
+### Changed
+- replace python builtin exceptions(e. g. RuntimeError) with custom ones 
+
 
 ## [1.4.0]
 

--- a/pyodata/exceptions.py
+++ b/pyodata/exceptions.py
@@ -12,6 +12,28 @@ class PyODataModelError(PyODataException):
     """Raised when model error occurs"""
 
 
+class PyODataRuntimeError(PyODataException):
+    """ Raised when an error accures after initial state is set.
+        e. g. when trying to set entity type for EntitySet for the second time
+    """
+
+
+class PyODataValueError(PyODataException):
+    """ Raised when an value is invalid
+        e. g. malformated input, value is out of range, entity has two properties with same name etc
+    """
+
+
+class PyODataKeyError(PyODataException):
+    """ Raised when nonexistent element is requested
+        e. g. property, entity set etc...
+    """
+
+
+class PyODataTypeError(PyODataException):
+    """ Raised when type error occurs"""
+
+
 class PyODataParserError(PyODataException):
     """Raised when parser error occurs"""
 


### PR DESCRIPTION
This commit is divided into these subtasks:
1. Categorizing all exceptions into groups[1][2]
2. Creating custom exceptions(all are annotated directly in file exceptions.py)
3. Replacing all raise EXCEPTION with newly created ones
4. Resolving dependent try-catch block, i. e. replace builtin exceptions in catch statements.

The 4th task is a bit tricky. I had to change the code a bit more to reflect things such as certain catch block being redundant(model line 1170, 1074-1078, 1155), multiple previously different exceptions being now caught as one(model lines 1191-1210)

Tests have been changed accordingly. In a few places, assert_logging_policy was replaced by caplog. It is a preferable practice and doing so made it easier to adjust the test.

Also, a bug causing the test silently passing when it should not have was found on the line 1245-1250.

[1] https://github.com/mamiksik/python-pyodata/wiki/Exceptions
[2] https://github.com/mamiksik/python-pyodata/wiki/Exceptions-rewrite
