### PR TITLE
update travis.yml - check multiple lxml version

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,10 +5,21 @@ python:
   - "3.6"
   - "3.7"
   - "3.8"
+  
+env:
+  - LXML_VERSION=3.7.3
+  - LXML_VERSION=3.8.0
+  - LXML_VERSION=4.0.0
+  - LXML_VERSION=4.1.1  
+  - LXML_VERSION=4.2.6
+  - LXML_VERSION=4.3.5
+  - LXML_VERSION=4.4.3
+  - LXML_VERSION=4.5.0
 
 # command to install dependencies
 install:
   - pip install .
+  - pip install -q lxml==LXML_VERSION
   - pip install -r dev-requirements.txt
   - pip install -r requirements.txt
   - pip install bandit

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,10 +16,26 @@ env:
   - LXML_VERSION=4.4.3
   - LXML_VERSION=4.5.0
 
+jobs:
+  exclude:
+    - python: 3.7
+      env: LXML_VERSION=3.7.3
+    - python: 3.7
+      env: LXML_VERSION=3.8.0
+    - python: 3.7
+      env: LXML_VERSION=4.0.0  
+    - python: 3.8
+      env: LXML_VERSION=3.7.3
+    - python: 3.8
+      env: LXML_VERSION=3.8.0
+    - python: 3.8
+      env: LXML_VERSION=4.0.0       
+      
+
 # command to install dependencies
 install:
   - pip install .
-  - pip install -q lxml==$LXML_VERSION
+  - pip install lxml==$LXML_VERSION
   - pip install -r dev-requirements.txt
   - pip install -r requirements.txt
   - pip install bandit

--- a/.travis.yml
+++ b/.travis.yml
@@ -19,7 +19,7 @@ env:
 # command to install dependencies
 install:
   - pip install .
-  - pip install -q lxml==LXML_VERSION
+  - pip install -q lxml==$LXML_VERSION
   - pip install -r dev-requirements.txt
   - pip install -r requirements.txt
   - pip install bandit


### PR DESCRIPTION
Since we provide pyodata as library and lxml is unpinned dependency, we should check at least major stable releases of lxml. Travis-CI has limit 200 concurrent jobs for open source, currently we use 3x8=24 combinations of python and lxml versions.