### PR TITLE
Fixed filter not working for services that require URLEncoded filters

### DIFF
--- a/pyodata/v2/service.py
+++ b/pyodata/v2/service.py
@@ -14,6 +14,13 @@ from email.parser import Parser
 from http.client import HTTPResponse
 from io import BytesIO
 
+try:
+    # For Python 3.0 and later
+    from urllib.parse import quote
+except ImportError:
+    # Fallback to urllib2
+    from urllib2 import quote
+
 from pyodata.exceptions import HttpError, PyODataException, ExpressionError
 from . import model
 
@@ -592,7 +599,7 @@ class QueryRequest(ODataHttpRequest):
     def filter(self, filter_val):
         """Sets the filter expression."""
         # returns QueryRequest
-        self._filter = filter_val
+        self._filter = quote(filter_val)
         return self
 
     # def nav(self, key_value, nav_property):


### PR DESCRIPTION
Some services need the filter query string to be URLEncoded for the query to work.

All SAP products support URL Encoded filter strings however not all OData v2 implementations support non URL Encoded strings.