### PR TITLE
service: add service wide configuration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Added
 - Specify PATCH or PUT method for EntityUpdateRequest - Barton Ip
+- Add a Service wide configuration (e.g. http.update\_method) - Jakub Filak
 - <, <=, >, >= operators on GetEntitySetFilter - Barton Ip
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ## [Unreleased]
 
 ### Added
-- Specify PATCH or PUT method for EntityUpdateRequest - Barton Ip
+- Specify PATCH, PUT, or MERGE method for EntityUpdateRequest - Barton Ip
 - Add a Service wide configuration (e.g. http.update\_method) - Jakub Filak
 - <, <=, >, >= operators on GetEntitySetFilter - Barton Ip
 

--- a/pyodata/v2/service.py
+++ b/pyodata/v2/service.py
@@ -1157,7 +1157,7 @@ class EntitySetProxy:
         return EntityCreateRequest(self._service.url, self._service.connection, create_entity_handler, self._entity_set,
                                    self.last_segment)
 
-    def update_entity(self, key=None, method="PATCH", **kwargs):
+    def update_entity(self, key=None, method=None, **kwargs):
         """Updates an existing entity in the given entity-set."""
 
         def update_entity_handler(response):
@@ -1173,6 +1173,9 @@ class EntitySetProxy:
             entity_key = EntityKey(self._entity_set.entity_type, key, **kwargs)
 
         self._logger.info('Updating entity %s for key %s and args %s', self._entity_set.entity_type.name, key, kwargs)
+
+        if method is None:
+            method = self._service.config['http']['update_method']
 
         return EntityModifyRequest(self._service.url, self._service.connection, update_entity_handler, self._entity_set,
                                    entity_key, method=method)
@@ -1309,6 +1312,8 @@ class Service:
         self._entity_container = EntityContainer(self)
         self._function_container = FunctionContainer(self)
 
+        self._config = {'http': {'update_method': 'PATCH'}}
+
     @property
     def schema(self):
         """Parsed metadata"""
@@ -1338,6 +1343,12 @@ class Service:
         """Functions proxy"""
 
         return self._function_container
+
+    @property
+    def config(self):
+        """Service specific configuration"""
+
+        return self._config
 
     def http_get(self, path, connection=None):
         """HTTP GET response for the passed path in the service"""

--- a/pyodata/v2/service.py
+++ b/pyodata/v2/service.py
@@ -512,6 +512,8 @@ class EntityModifyRequest(ODataHttpRequest):
        Call execute() to send the update-request to the OData service
        and get the modified entity."""
 
+    ALLOWED_HTTP_METHODS = ['PATCH', 'PUT', 'MERGE']
+
     def __init__(self, url, connection, handler, entity_set, entity_key, method="PATCH"):
         super(EntityModifyRequest, self).__init__(url, connection, handler)
         self._logger = logging.getLogger(LOGGER_NAME)
@@ -519,10 +521,10 @@ class EntityModifyRequest(ODataHttpRequest):
         self._entity_type = entity_set.entity_type
         self._entity_key = entity_key
 
-        if method.upper() not in ["PATCH", "PUT"]:
-            raise ValueError("Method must be either PATCH or PUT")
-
-        self._method = method
+        self._method = method.upper()
+        if self._method not in EntityModifyRequest.ALLOWED_HTTP_METHODS:
+            raise ValueError('The value "{}" is not on the list of allowed Entity Update HTTP Methods: {}'
+                             .format(method, ', '.join(EntityModifyRequest.ALLOWED_HTTP_METHODS)))
 
         self._values = {}
 

--- a/tests/test_service_v2.py
+++ b/tests/test_service_v2.py
@@ -703,6 +703,22 @@ def test_update_entity_with_no_method_specified(service):
     assert query.get_method() == "PATCH"
 
 
+def test_update_entity_with_service_config_set_to_put(service):
+    """Make sure the method update_entity handles correctly when no method is specified"""
+
+    # pylint: disable=redefined-outer-name
+
+
+    key = EntityKey(
+        service.schema.entity_type('TemperatureMeasurement'),
+        Sensor='sensor1',
+        Date=datetime.datetime(2017, 12, 24, 18, 0))
+
+    service.config['http']['update_method'] = "PUT"
+    query = service.entity_sets.TemperatureMeasurements.update_entity(key)
+    assert query.get_method() == "PUT"
+
+
 def test_update_entity_with_wrong_method_specified(service):
     """Make sure the method update_entity raises ValueError when wrong method is specified"""
 

--- a/tests/test_service_v2.py
+++ b/tests/test_service_v2.py
@@ -687,6 +687,20 @@ def test_update_entity_with_patch_method_specified(service):
     query = service.entity_sets.TemperatureMeasurements.update_entity(key, method="PATCH")
     assert query.get_method() == "PATCH"
 
+def test_update_entity_with_merge_method_specified(service):
+    """Make sure the method update_entity handles correctly when MERGE method is specified"""
+
+    # pylint: disable=redefined-outer-name
+
+
+    key = EntityKey(
+        service.schema.entity_type('TemperatureMeasurement'),
+        Sensor='sensor1',
+        Date=datetime.datetime(2017, 12, 24, 18, 0))
+
+    query = service.entity_sets.TemperatureMeasurements.update_entity(key, method='merge')
+    assert query.get_method() == 'MERGE'
+
 
 def test_update_entity_with_no_method_specified(service):
     """Make sure the method update_entity handles correctly when no method is specified"""
@@ -730,8 +744,10 @@ def test_update_entity_with_wrong_method_specified(service):
         Sensor='sensor1',
         Date=datetime.datetime(2017, 12, 24, 18, 0))
 
-    with pytest.raises(ValueError):
-        service.entity_sets.TemperatureMeasurements.update_entity(key, method="DELETE")
+    with pytest.raises(ValueError) as caught_ex:
+        service.entity_sets.TemperatureMeasurements.update_entity(key, method='DELETE')
+
+    assert str(caught_ex.value).startswith('The value "DELETE" is not on the list of allowed Entity Update HTTP Methods: PATCH, PUT, MERGE')
 
 
 def test_get_entity_with_entity_key_and_other_params(service):


### PR DESCRIPTION
In the case where we need to update several entity sets,
we probably don't want to specify HTTP method for each of them.

This patch does nothing but enhances user convenience.