### PR TITLE
Response headers passed through to EntityProxy

### DIFF
--- a/docs/usage/advanced.rst
+++ b/docs/usage/advanced.rst
@@ -45,7 +45,19 @@ Error handling
 --------------
 
 PyOData returns *HttpError* when the response code does not match the expected
-code. Basically the exception is raised for all status codes >= 400.
+code. Basically the exception is raised for all status codes >= 400 and its
+instances have the property response which holds return value of the library
+making HTTP requests.
+
+For example, the following code show how to print out error details if
+Python Requests is used as the HTTP communication library.
+
+.. code-block:: python
+
+    try:
+        new_data = create_request.execute()
+    except pyodata.exceptions.HttpError as ex:
+        print(ex.response.text)
 
 In the case you know the implementation of back-end part and you want to show
 accurate errors reported by your service, you can replace *HttpError* by your

--- a/pyodata/v2/service.py
+++ b/pyodata/v2/service.py
@@ -512,12 +512,17 @@ class EntityModifyRequest(ODataHttpRequest):
        Call execute() to send the update-request to the OData service
        and get the modified entity."""
 
-    def __init__(self, url, connection, handler, entity_set, entity_key):
+    def __init__(self, url, connection, handler, entity_set, entity_key, method="PATCH"):
         super(EntityModifyRequest, self).__init__(url, connection, handler)
         self._logger = logging.getLogger(LOGGER_NAME)
         self._entity_set = entity_set
         self._entity_type = entity_set.entity_type
         self._entity_key = entity_key
+
+        if method.upper() not in ["PATCH", "PUT"]:
+            raise ValueError("Method must be either PATCH or PUT")
+
+        self._method = method
 
         self._values = {}
 
@@ -531,7 +536,7 @@ class EntityModifyRequest(ODataHttpRequest):
 
     def get_method(self):
         # pylint: disable=no-self-use
-        return 'PATCH'
+        return self._method
 
     def get_body(self):
         # pylint: disable=no-self-use
@@ -1154,7 +1159,7 @@ class EntitySetProxy:
         return EntityCreateRequest(self._service.url, self._service.connection, create_entity_handler, self._entity_set,
                                    self.last_segment)
 
-    def update_entity(self, key=None, **kwargs):
+    def update_entity(self, key=None, method="PATCH", **kwargs):
         """Updates an existing entity in the given entity-set."""
 
         def update_entity_handler(response):
@@ -1172,7 +1177,7 @@ class EntitySetProxy:
         self._logger.info('Updating entity %s for key %s and args %s', self._entity_set.entity_type.name, key, kwargs)
 
         return EntityModifyRequest(self._service.url, self._service.connection, update_entity_handler, self._entity_set,
-                                   entity_key)
+                                   entity_key, method=method)
 
     def delete_entity(self, key: EntityKey = None, **kwargs):
         """Delete the entity"""

--- a/pyodata/v2/service.py
+++ b/pyodata/v2/service.py
@@ -14,6 +14,13 @@ from email.parser import Parser
 from http.client import HTTPResponse
 from io import BytesIO
 
+try:
+    # For Python 3.0 and later
+    from urllib.parse import quote
+except ImportError:
+    # Fallback to urllib2
+    from urllib2 import quote
+
 from pyodata.exceptions import HttpError, PyODataException, ExpressionError
 from . import model
 
@@ -592,7 +599,7 @@ class QueryRequest(ODataHttpRequest):
     def filter(self, filter_val):
         """Sets the filter expression."""
         # returns QueryRequest
-        self._filter = filter_val
+        self._filter = quote(filter_val)
         return self
 
     # def nav(self, key_value, nav_property):

--- a/pyodata/v2/service.py
+++ b/pyodata/v2/service.py
@@ -956,6 +956,18 @@ class GetEntitySetFilter:
     def __ne__(self, value):
         return GetEntitySetFilter.format_filter(self._proprty, 'ne', value)
 
+    def __lt__(self, value):
+        return GetEntitySetFilter.format_filter(self._proprty, 'lt', value)
+
+    def __le__(self, value):
+        return GetEntitySetFilter.format_filter(self._proprty, 'le', value)
+
+    def __ge__(self, value):
+        return GetEntitySetFilter.format_filter(self._proprty, 'ge', value)
+    
+    def __gt__(self, value):
+        return GetEntitySetFilter.format_filter(self._proprty, 'gt', value)
+
 
 class GetEntitySetRequest(QueryRequest):
     """GET on EntitySet"""

--- a/pyodata/v2/service.py
+++ b/pyodata/v2/service.py
@@ -235,11 +235,11 @@ class EntityKey:
 class ODataHttpRequest:
     """Deferred HTTP Request"""
 
-    def __init__(self, url, connection, handler, headers=None):
+    def __init__(self, url, connection, handler, headers={}):
         self._connection = connection
         self._url = url
         self._handler = handler
-        self._headers = headers
+        self.headers = headers
         self._logger = logging.getLogger(LOGGER_NAME)
 
     @property
@@ -284,7 +284,7 @@ class ODataHttpRequest:
         # pylint: disable=assignment-from-none
         body = self.get_body()
 
-        headers = {} if self._headers is None else self._headers
+        headers = self.headers
 
         # pylint: disable=assignment-from-none
         extra_headers = self.get_headers()
@@ -351,7 +351,7 @@ class EntityGetRequest(ODataHttpRequest):
         return self._entity_set_proxy.last_segment + self._entity_key.to_key_string()
 
     def get_headers(self):
-        return {'Accept': 'application/json'}
+        return {'Accept': 'application/json', **self.headers}
 
     def get_query_params(self):
         qparams = super(EntityGetRequest, self).get_query_params()
@@ -448,7 +448,7 @@ class EntityCreateRequest(ODataHttpRequest):
         return json.dumps(self._get_body())
 
     def get_headers(self):
-        return {'Accept': 'application/json', 'Content-Type': 'application/json', 'X-Requested-With': 'X'}
+        return {'Accept': 'application/json', 'Content-Type': 'application/json', 'X-Requested-With': 'X', **self.headers}
 
     @staticmethod
     def _build_values(entity_type, entity):
@@ -541,7 +541,7 @@ class EntityModifyRequest(ODataHttpRequest):
         return json.dumps(body)
 
     def get_headers(self):
-        return {'Accept': 'application/json', 'Content-Type': 'application/json'}
+        return {'Accept': 'application/json', 'Content-Type': 'application/json', **self.headers}
 
     def set(self, **kwargs):
         """Set properties to be changed."""
@@ -639,6 +639,7 @@ class QueryRequest(ODataHttpRequest):
 
         return {
             'Accept': 'application/json',
+            **self.headers
         }
 
     def get_query_params(self):
@@ -699,6 +700,7 @@ class FunctionRequest(QueryRequest):
     def get_headers(self):
         return {
             'Accept': 'application/json',
+            **self.headers
         }
 
 
@@ -1445,7 +1447,7 @@ class MultipartRequest(ODataHttpRequest):
 
     def get_headers(self):
         # pylint: disable=no-self-use
-        return {'Content-Type': 'multipart/mixed;boundary={}'.format(self.get_boundary())}
+        return {'Content-Type': 'multipart/mixed;boundary={}'.format(self.get_boundary()), **self.headers}
 
     def get_body(self):
         return encode_multipart(self.get_boundary(), self.requests)

--- a/pyodata/v2/service.py
+++ b/pyodata/v2/service.py
@@ -741,7 +741,7 @@ class EntityProxy:
 
     # pylint: disable=too-many-branches,too-many-nested-blocks
 
-    def __init__(self, service, entity_set, entity_type, proprties=None, entity_key=None):
+    def __init__(self, service, entity_set, entity_type, proprties=None, entity_key=None, headers=None):
         self._logger = logging.getLogger(LOGGER_NAME)
         self._service = service
         self._entity_set = entity_set
@@ -749,6 +749,8 @@ class EntityProxy:
         self._key_props = entity_type.key_proprties
         self._cache = dict()
         self._entity_key = entity_key
+
+        self.headers = dict(headers) if headers else dict()
 
         self._logger.debug('New entity proxy instance of type %s from properties: %s', entity_type.name, proprties)
 
@@ -1122,7 +1124,7 @@ class EntitySetProxy:
 
             entity = response.json()['d']
 
-            return EntityProxy(self._service, self._entity_set, self._entity_set.entity_type, entity)
+            return EntityProxy(self._service, self._entity_set, self._entity_set.entity_type, entity, headers=response.headers)
 
         if key is not None and isinstance(key, EntityKey):
             entity_key = key

--- a/tests/test_service_v2.py
+++ b/tests/test_service_v2.py
@@ -1251,7 +1251,8 @@ def test_get_entity(service):
             'NameFirst': 'Rob',
             'NameLast': 'Ickes'
         }},
-        status=200)
+        status=200,
+        headers={"ETag": "W/*"})
 
     request = service.entity_sets.Employees.get_entity(23)
 
@@ -1261,6 +1262,7 @@ def test_get_entity(service):
     assert emp.ID == 23
     assert emp.NameFirst == 'Rob'
     assert emp.NameLast == 'Ickes'
+    assert emp.headers == {"ETag": "W/*", "Content-Type": "application/json"}
 
 
 @responses.activate

--- a/tests/test_service_v2.py
+++ b/tests/test_service_v2.py
@@ -1332,6 +1332,50 @@ def test_get_entity_set_query_filter_ne(service):
     assert filter_str == "Key ne 'bar'"
 
 
+def test_get_entity_set_query_filter_lt(service):
+    """Test the operator 'lt' of $filter for humans"""
+
+    # pylint: disable=redefined-outer-name, invalid-name
+
+    request = service.entity_sets.Cars.get_entities()
+    filter_str = request.Price < 2
+
+    assert filter_str == "Price lt 2"
+
+
+def test_get_entity_set_query_filter_le(service):
+    """Test the operator 'le' of $filter for humans"""
+
+    # pylint: disable=redefined-outer-name, invalid-name
+
+    request = service.entity_sets.Cars.get_entities()
+    filter_str = request.Price <= 2
+
+    assert filter_str == "Price le 2"
+
+
+def test_get_entity_set_query_filter_ge(service):
+    """Test the operator 'ge' of $filter for humans"""
+
+    # pylint: disable=redefined-outer-name, invalid-name
+
+    request = service.entity_sets.Cars.get_entities()
+    filter_str = request.Price >= 2
+
+    assert filter_str == "Price ge 2"
+
+
+def test_get_entity_set_query_filter_gt(service):
+    """Test the operator 'gt' of $filter for humans"""
+
+    # pylint: disable=redefined-outer-name, invalid-name
+
+    request = service.entity_sets.Cars.get_entities()
+    filter_str = request.Price > 2
+
+    assert filter_str == "Price gt 2"
+
+
 def test_get_entity_set_query_filter_and(service):
     """Test the operator 'and' of $filter for humans"""
 

--- a/tests/test_service_v2.py
+++ b/tests/test_service_v2.py
@@ -734,7 +734,7 @@ def test_get_entity_with_entity_key_and_other_params(service):
 
 def test_get_entities_with_custom_headers(service):
     query = service.entity_sets.TemperatureMeasurements.get_entities()
-    query.headers = {"X-Foo": "bar"}
+    query.add_headers({"X-Foo": "bar"})
 
     assert query.get_headers() == {"Accept": "application/json", "X-Foo": "bar"}
 
@@ -746,7 +746,7 @@ def test_get_entity_with_custom_headers(service):
         Date=datetime.datetime(2017, 12, 24, 18, 0))
 
     query = service.entity_sets.TemperatureMeasurements.get_entity(key)
-    query.headers = {"X-Foo": "bar"}
+    query.add_headers({"X-Foo": "bar"})
 
     assert query.get_headers() == {"Accept": "application/json", "X-Foo": "bar"}
 
@@ -758,30 +758,38 @@ def test_update_entities_with_custom_headers(service):
         Date=datetime.datetime(2017, 12, 24, 18, 0))
 
     query = service.entity_sets.TemperatureMeasurements.update_entity(key)
-    query.headers = {"X-Foo": "bar"}
+    query.add_headers({"X-Foo": "bar"})
 
     assert query.get_headers() == {"Accept": "application/json", "Content-Type": "application/json", "X-Foo": "bar"}
 
 
 def test_create_entity_with_custom_headers(service):
     query = service.entity_sets.TemperatureMeasurements.create_entity()
-    query.headers = {"X-Foo": "bar"}
+    query.add_headers({"X-Foo": "bar"})
 
     assert query.get_headers() == {"Accept": "application/json", "Content-Type": "application/json", "X-Requested-With": "X", "X-Foo": "bar"}
 
 
 def test_create_entity_with_overwriting_custom_headers(service):
     query = service.entity_sets.TemperatureMeasurements.create_entity()
-    query.headers = {"X-Requested-With": "bar"}
+    query.add_headers({"X-Requested-With": "bar"})
 
     assert query.get_headers() == {"Accept": "application/json", "Content-Type": "application/json", "X-Requested-With": "bar"}
 
 
 def test_create_entity_with_blank_custom_headers(service):
     query = service.entity_sets.TemperatureMeasurements.create_entity()
-    query.headers = {}
+    query.add_headers({})
 
     assert query.get_headers() == {"Accept": "application/json", "Content-Type": "application/json", "X-Requested-With": "X"}
+
+
+def test_pass_incorrect_header_type(service):
+    query = service.entity_sets.TemperatureMeasurements.create_entity()
+
+    with pytest.raises(TypeError) as ex:
+        query.add_headers(69420)
+        assert str(ex) == "TypeError: Headers must be of type 'dict' not <class 'int'>"
 
 
 @responses.activate

--- a/tests/test_service_v2.py
+++ b/tests/test_service_v2.py
@@ -658,6 +658,66 @@ def test_update_entity_with_entity_key(service):
     assert query.get_path() == "TemperatureMeasurements(Sensor='sensor1',Date=datetime'2017-12-24T18:00:00')"
 
 
+def test_update_entity_with_put_method_specified(service):
+    """Make sure the method update_entity handles correctly when PUT method is specified"""
+
+    # pylint: disable=redefined-outer-name
+
+
+    key = EntityKey(
+        service.schema.entity_type('TemperatureMeasurement'),
+        Sensor='sensor1',
+        Date=datetime.datetime(2017, 12, 24, 18, 0))
+
+    query = service.entity_sets.TemperatureMeasurements.update_entity(key, method="PUT")
+    assert query.get_method() == "PUT"
+
+
+def test_update_entity_with_patch_method_specified(service):
+    """Make sure the method update_entity handles correctly when PATCH method is specified"""
+
+    # pylint: disable=redefined-outer-name
+
+
+    key = EntityKey(
+        service.schema.entity_type('TemperatureMeasurement'),
+        Sensor='sensor1',
+        Date=datetime.datetime(2017, 12, 24, 18, 0))
+
+    query = service.entity_sets.TemperatureMeasurements.update_entity(key, method="PATCH")
+    assert query.get_method() == "PATCH"
+
+
+def test_update_entity_with_no_method_specified(service):
+    """Make sure the method update_entity handles correctly when no method is specified"""
+
+    # pylint: disable=redefined-outer-name
+
+
+    key = EntityKey(
+        service.schema.entity_type('TemperatureMeasurement'),
+        Sensor='sensor1',
+        Date=datetime.datetime(2017, 12, 24, 18, 0))
+
+    query = service.entity_sets.TemperatureMeasurements.update_entity(key)
+    assert query.get_method() == "PATCH"
+
+
+def test_update_entity_with_wrong_method_specified(service):
+    """Make sure the method update_entity raises ValueError when wrong method is specified"""
+
+    # pylint: disable=redefined-outer-name
+
+
+    key = EntityKey(
+        service.schema.entity_type('TemperatureMeasurement'),
+        Sensor='sensor1',
+        Date=datetime.datetime(2017, 12, 24, 18, 0))
+
+    with pytest.raises(ValueError):
+        service.entity_sets.TemperatureMeasurements.update_entity(key, method="DELETE")
+
+
 def test_get_entity_with_entity_key_and_other_params(service):
     """Make sure the method update_entity handles correctly the parameter key which is EntityKey"""
 

--- a/tests/test_service_v2.py
+++ b/tests/test_service_v2.py
@@ -671,6 +671,59 @@ def test_get_entity_with_entity_key_and_other_params(service):
     query = service.entity_sets.TemperatureMeasurements.update_entity(key=key, Foo='Bar')
     assert query.get_path() == "TemperatureMeasurements(Sensor='sensor1',Date=datetime'2017-12-24T18:00:00')"
 
+
+def test_get_entities_with_custom_headers(service):
+    query = service.entity_sets.TemperatureMeasurements.get_entities()
+    query.headers = {"X-Foo": "bar"}
+
+    assert query.get_headers() == {"Accept": "application/json", "X-Foo": "bar"}
+
+
+def test_get_entity_with_custom_headers(service):
+    key = EntityKey(
+        service.schema.entity_type('TemperatureMeasurement'),
+        Sensor='sensor1',
+        Date=datetime.datetime(2017, 12, 24, 18, 0))
+
+    query = service.entity_sets.TemperatureMeasurements.get_entity(key)
+    query.headers = {"X-Foo": "bar"}
+
+    assert query.get_headers() == {"Accept": "application/json", "X-Foo": "bar"}
+
+
+def test_update_entities_with_custom_headers(service):
+    key = EntityKey(
+        service.schema.entity_type('TemperatureMeasurement'),
+        Sensor='sensor1',
+        Date=datetime.datetime(2017, 12, 24, 18, 0))
+
+    query = service.entity_sets.TemperatureMeasurements.update_entity(key)
+    query.headers = {"X-Foo": "bar"}
+
+    assert query.get_headers() == {"Accept": "application/json", "Content-Type": "application/json", "X-Foo": "bar"}
+
+
+def test_create_entity_with_custom_headers(service):
+    query = service.entity_sets.TemperatureMeasurements.create_entity()
+    query.headers = {"X-Foo": "bar"}
+
+    assert query.get_headers() == {"Accept": "application/json", "Content-Type": "application/json", "X-Requested-With": "X", "X-Foo": "bar"}
+
+
+def test_create_entity_with_overwriting_custom_headers(service):
+    query = service.entity_sets.TemperatureMeasurements.create_entity()
+    query.headers = {"X-Requested-With": "bar"}
+
+    assert query.get_headers() == {"Accept": "application/json", "Content-Type": "application/json", "X-Requested-With": "bar"}
+
+
+def test_create_entity_with_blank_custom_headers(service):
+    query = service.entity_sets.TemperatureMeasurements.create_entity()
+    query.headers = {}
+
+    assert query.get_headers() == {"Accept": "application/json", "Content-Type": "application/json", "X-Requested-With": "X"}
+
+
 @responses.activate
 def test_get_entities(service):
     """Get entities"""


### PR DESCRIPTION
A `headers` keyword argument has been added in `EntityProxy` to allow the passthrough of the response headers which includes the `ETag` of a particular entity.

This allows the ETag to be extracted from the entity and used in an If-Match header as required.