### PR TITLE
add new property is_valid for Schema class

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ### Added
 - Add inlinecount support - Stoyko Stoev
 - Add a ProgramError exception - Stoyko Stoev
+- Add is_valid schema property - Petr Hanak
 
 ### Fixed
 - Passing custom URL query parameters for Entity Requests - Sylvain Fankhauser

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -29,6 +29,7 @@ def test_create_client_for_local_metadata(metadata):
     client = pyodata.Client(SERVICE_URL, requests, metadata=metadata)
 
     assert isinstance(client, pyodata.v2.service.Service)
+    assert client.schema.is_valid == True
 
     assert len(client.schema.entity_sets) != 0
 
@@ -53,7 +54,7 @@ def test_create_service_application_xml(metadata):
     client = pyodata.Client(SERVICE_URL + '/', requests)
 
     assert isinstance(client, pyodata.v2.service.Service)
-
+    assert client.schema.is_valid == True
 
 @responses.activate
 def test_create_service_text_xml(metadata):
@@ -75,7 +76,7 @@ def test_create_service_text_xml(metadata):
     client = pyodata.Client(SERVICE_URL + '/', requests)
 
     assert isinstance(client, pyodata.v2.service.Service)
-
+    assert client.schema.is_valid == True
 
 @responses.activate
 def test_metadata_not_reachable():
@@ -91,7 +92,6 @@ def test_metadata_not_reachable():
         pyodata.Client(SERVICE_URL, requests)
 
     assert str(e_info.value).startswith('Metadata request failed')
-
 
 @responses.activate
 def test_metadata_saml_not_authorized():

--- a/tests/test_model_v2.py
+++ b/tests/test_model_v2.py
@@ -1009,6 +1009,7 @@ def test_faulty_association(xml_builder_factory):
         ))
 
     schema = metadata.build()
+    assert schema.is_valid == False
     assert isinstance(schema.associations[0], NullAssociation)
 
     with pytest.raises(PyODataModelError) as typ_ex_info:
@@ -1035,6 +1036,7 @@ def test_faulty_association_set(xml_builder_factory):
         ))
 
     schema = metadata.build()
+    assert schema.is_valid == False
     assert isinstance(schema.association_set('toDataEntitySet'), NullAssociation)
 
     with pytest.raises(PyODataModelError) as typ_ex_info:


### PR DESCRIPTION
Consider this an idea thrown away. If OK, there should definitely be added more tests for various invalid metadata files parsed and checked for expected result, but at the moment is IMHO enough just modifying existing test cases. 

Rationale for new property:

Policies Fatal, Warning a Ignore are modifying the behavior in a way that following is not possible to do (create simple validator)

1)	Go trough entire metadata for having all problems logged (exceptions thrown) - Fatal stops on first error
2)	Some kind of information that there are real problem in metadata - Warning will go to the end, but mix warning messages (unsupported annotation etc.) with real metadata parsing problem (various exceptions). Parsing logger is possible but ugly.
3)	Policies as they are so far are actually useful for many usages of Pyodata. But IMHO such new property for metadata state (valid/not_parsed_correctly) is useful on is own.
