### PR TITLE
Update .pylintrc - disable new check from 2.6.0

### DIFF
--- a/.pylintrc
+++ b/.pylintrc
@@ -65,7 +65,7 @@ confidence=
 # --enable=similarities". If you want to run only the classes checker, but have
 # no Warning level messages displayed, use"--disable=all --enable=classes
 # --disable=W"
-disable=locally-disabled
+disable=locally-disabled, super-with-arguments, raise-missing-from
 
 
 [REPORTS]


### PR DESCRIPTION
This is a quick fix for issue #130. Rules should be enabled with respective code refactoring.