### PR TITLE
chore: %-formatting to f-string

### DIFF
--- a/.pylintrc
+++ b/.pylintrc
@@ -65,7 +65,7 @@ confidence=
 # --enable=similarities". If you want to run only the classes checker, but have
 # no Warning level messages displayed, use"--disable=all --enable=classes
 # --disable=W"
-disable=locally-disabled, super-with-arguments, raise-missing-from, logging-fstring-interpolation
+disable=locally-disabled, super-with-arguments, raise-missing-from
 
 
 [REPORTS]

--- a/.pylintrc
+++ b/.pylintrc
@@ -65,7 +65,7 @@ confidence=
 # --enable=similarities". If you want to run only the classes checker, but have
 # no Warning level messages displayed, use"--disable=all --enable=classes
 # --disable=W"
-disable=locally-disabled, super-with-arguments, raise-missing-from
+disable=locally-disabled, super-with-arguments, raise-missing-from, logging-fstring-interpolation
 
 
 [REPORTS]

--- a/pyodata/client.py
+++ b/pyodata/client.py
@@ -19,12 +19,12 @@ def _fetch_metadata(connection, url, logger):
 
     if resp.status_code != 200:
         raise HttpError(
-            'Metadata request failed, status code: {}, body:\n{}'.format(resp.status_code, resp.content), resp)
+            f'Metadata request failed, status code: {resp.status_code}, body:\n{resp.content}', resp)
 
     mime_type = resp.headers['content-type']
     if not any((typ in ['application/xml', 'text/xml'] for typ in mime_type.split(';'))):
         raise HttpError(
-            'Metadata request did not return XML, MIME type: {}, body:\n{}'.format(mime_type, resp.content),
+            f'Metadata request did not return XML, MIME type: {mime_type}, body:\n{resp.content}',
             resp)
 
     return resp.content
@@ -73,4 +73,4 @@ class Client:
 
             return service
 
-        raise PyODataException('No implementation for selected odata version {}'.format(odata_version))
+        raise PyODataException(f'No implementation for selected odata version {odata_version}')

--- a/pyodata/v2/model.py
+++ b/pyodata/v2/model.py
@@ -1254,7 +1254,7 @@ class Schema:
             for annotation_group in schema_node.xpath('edm:Annotations', namespaces=ANNOTATION_NAMESPACES):
                 for annotation in ExternalAnnontation.from_etree(annotation_group):
                     if not annotation.element_namespace != schema.namespaces:
-                        modlog().warning(f"{annotation} not in the namespaces {','.join(schema.namespaces)}")
+                        modlog().warning('{0} not in the namespaces {1}'.format(annotation, ','.join(schema.namespaces)))
                         continue
 
                     try:
@@ -2155,7 +2155,7 @@ class Annotation:
         if term in SAP_ANNOTATION_VALUE_LIST:
             return ValueHelper.from_etree(target, annotation_node)
 
-        modlog().warning(f'Unsupported Annotation({term})')
+        modlog().warning('Unsupported Annotation({0})'.format(term))
         return None
 
 
@@ -2165,7 +2165,7 @@ class ExternalAnnontation:
         target = annotations_node.get('Target')
 
         if annotations_node.get('Qualifier'):
-            modlog().warning(f'Ignoring qualified Annotations of {target}')
+            modlog().warning('Ignoring qualified Annotations of {}'.format(target))
             return
 
         for annotation in annotations_node.xpath('edm:Annotation', namespaces=ANNOTATION_NAMESPACES):

--- a/pyodata/v2/model.py
+++ b/pyodata/v2/model.py
@@ -153,10 +153,10 @@ class Identifier:
         self._name = name
 
     def __repr__(self):
-        return "{0}({1})".format(self.__class__.__name__, self._name)
+        return f"{self.__class__.__name__}({self._name})"
 
     def __str__(self):
-        return "{0}({1})".format(self.__class__.__name__, self._name)
+        return f"{self.__class__.__name__}({self._name})"
 
     @property
     def name(self):
@@ -225,7 +225,7 @@ class Types:
             Types.Types[typ.name] = typ
 
         # automatically create and register collection variant if not exists
-        collection_name = 'Collection({})'.format(typ.name)
+        collection_name = f'Collection({typ.name})'
         # pylint: disable=unsupported-membership-test
         if collection_name not in Types.Types:
             collection_typ = Collection(typ.name, typ)
@@ -245,7 +245,7 @@ class Types:
         is_collection = name.lower().startswith('collection(') and name.endswith(')')
         if is_collection:
             name = name[11:-1]  # strip collection() decorator
-            search_name = 'Collection({})'.format(name)
+            search_name = f'Collection({name})'
 
         # pylint: disable=unsubscriptable-object
         return Types.Types[search_name]
@@ -282,7 +282,7 @@ class EdmStructTypeSerializer:
 
         # pylint: disable=no-self-use
         if not edm_type:
-            raise PyODataException('Cannot encode value {} without complex type information'.format(value))
+            raise PyODataException(f'Cannot encode value {value} without complex type information')
 
         result = {}
         for type_prop in edm_type.proprties():
@@ -296,7 +296,7 @@ class EdmStructTypeSerializer:
 
         # pylint: disable=no-self-use
         if not edm_type:
-            raise PyODataException('Cannot decode value {} without complex type information'.format(value))
+            raise PyODataException(f'Cannot decode value {value} without complex type information')
 
         result = {}
         for type_prop in edm_type.proprties():
@@ -310,7 +310,7 @@ class EdmStructTypeSerializer:
 
         # pylint: disable=no-self-use
         if not edm_type:
-            raise PyODataException('Cannot decode value {} without complex type information'.format(value))
+            raise PyODataException(f'Cannot decode value {value} without complex type information')
 
         result = {}
         for type_prop in edm_type.proprties():
@@ -352,10 +352,10 @@ class EdmPrefixedTypTraits(TypTraits):
         return '{}\'{}\''.format(self._prefix, value)
 
     def from_literal(self, value):
-        matches = re.match("^{}'(.*)'$".format(self._prefix), value)
+        matches = re.match(f"^{self._prefix}'(.*)'$", value)
         if not matches:
             raise PyODataModelError(
-                "Malformed value {0} for primitive Edm type. Expected format is {1}'value'".format(value, self._prefix))
+                f"Malformed value {value} for primitive Edm type. Expected format is {self._prefix}'value'")
         return matches.group(1)
 
 
@@ -387,7 +387,7 @@ class EdmDateTimeTypTraits(EdmPrefixedTypTraits):
 
         if not isinstance(value, datetime.datetime):
             raise PyODataModelError(
-                'Cannot convert value of type {} to literal. Datetime format is required.'.format(type(value)))
+                f'Cannot convert value of type {type(value)} to literal. Datetime format is required.')
 
         # Sets timezone to none to avoid including timezone information in the literal form.
         return super(EdmDateTimeTypTraits, self).to_literal(value.replace(tzinfo=None).isoformat())
@@ -408,14 +408,14 @@ class EdmDateTimeTypTraits(EdmPrefixedTypTraits):
         matches = re.match(r"^/Date\((.*)\)/$", value)
         if not matches:
             raise PyODataModelError(
-                "Malformed value {0} for primitive Edm type. Expected format is /Date(value)/".format(value))
+                f"Malformed value {value} for primitive Edm type. Expected format is /Date(value)/")
         value = matches.group(1)
 
         try:
             # https://stackoverflow.com/questions/36179914/timestamp-out-of-range-for-platform-localtime-gmtime-function
             value = datetime.datetime(1970, 1, 1, tzinfo=current_timezone()) + datetime.timedelta(milliseconds=int(value))
         except ValueError:
-            raise PyODataModelError('Cannot decode datetime from value {}.'.format(value))
+            raise PyODataModelError(f'Cannot decode datetime from value {value}.')
 
         return value
 
@@ -435,7 +435,7 @@ class EdmDateTimeTypTraits(EdmPrefixedTypTraits):
                 try:
                     value = datetime.datetime.strptime(value, '%Y-%m-%dT%H:%M')
                 except ValueError:
-                    raise PyODataModelError('Cannot decode datetime from value {}.'.format(value))
+                    raise PyODataModelError(f'Cannot decode datetime from value {value}.')
 
         return value.replace(tzinfo=current_timezone())
 
@@ -620,7 +620,7 @@ class Collection(Typ):
         self._item_type = item_type
 
     def __repr__(self):
-        return 'Collection({})'.format(repr(self._item_type))
+        return f'Collection({repr(self._item_type)})'
 
     @property
     def is_collection(self):
@@ -637,14 +637,14 @@ class Collection(Typ):
     # pylint: disable=no-self-use
     def to_literal(self, value):
         if not isinstance(value, list):
-            raise PyODataException('Bad format: invalid list value {}'.format(value))
+            raise PyODataException(f'Bad format: invalid list value {value}')
 
         return [self._item_type.traits.to_literal(v) for v in value]
 
     # pylint: disable=no-self-use
     def from_json(self, value):
         if not isinstance(value, list):
-            raise PyODataException('Bad format: invalid list value {}'.format(value))
+            raise PyODataException(f'Bad format: invalid list value {value}')
 
         return [self._item_type.traits.from_json(v) for v in value]
 
@@ -688,10 +688,10 @@ class VariableDeclaration(Identifier):
     @typ.setter
     def typ(self, value):
         if self._typ is not None:
-            raise RuntimeError('Cannot replace {0} of {1} by {2}'.format(self._typ, self, value))
+            raise RuntimeError(f'Cannot replace {self._typ} of {self} by {value}')
 
         if value.name != self._type_info[1]:
-            raise RuntimeError('{0} cannot be the type of {1}'.format(value, self))
+            raise RuntimeError(f'{value} cannot be the type of {self}')
 
         self._typ = value
 
@@ -798,7 +798,7 @@ class Schema:
             if isinstance(etype, NullType):
                 return
 
-            collection_type_name = 'Collection({})'.format(etype.name)
+            collection_type_name = f'Collection({etype.name})'
             self.entity_types[collection_type_name] = Collection(etype.name, etype)
 
         def add_complex_type(self, ctype):
@@ -810,7 +810,7 @@ class Schema:
             if isinstance(ctype, NullType):
                 return
 
-            collection_type_name = 'Collection({})'.format(ctype.name)
+            collection_type_name = f'Collection({ctype.name})'
             self.complex_types[collection_type_name] = Collection(ctype.name, ctype)
 
         def add_enum_type(self, etype):
@@ -823,7 +823,7 @@ class Schema:
             try:
                 return super(Schema.Declarations, self).__getitem__(key)
             except KeyError:
-                raise KeyError('There is no Schema Namespace {}'.format(key))
+                raise KeyError(f'There is no Schema Namespace {key}')
 
     def __init__(self, config: Config):
         super(Schema, self).__init__()
@@ -833,7 +833,7 @@ class Schema:
         self._is_valid = False
 
     def __str__(self):
-        return "{0}({1})".format(self.__class__.__name__, ','.join(self.namespaces))
+        return f"{self.__class__.__name__}({','.join(self.namespaces)})"
 
     @property
     def namespaces(self):
@@ -869,7 +869,7 @@ class Schema:
             try:
                 return self._decls[namespace].entity_types[type_name]
             except KeyError:
-                raise KeyError('EntityType {} does not exist in Schema Namespace {}'.format(type_name, namespace))
+                raise KeyError(f'EntityType {type_name} does not exist in Schema Namespace {namespace}')
 
         for decl in list(self._decls.values()):
             try:
@@ -877,14 +877,14 @@ class Schema:
             except KeyError:
                 pass
 
-        raise KeyError('EntityType {} does not exist in any Schema Namespace'.format(type_name))
+        raise KeyError(f'EntityType {type_name} does not exist in any Schema Namespace')
 
     def complex_type(self, type_name, namespace=None):
         if namespace is not None:
             try:
                 return self._decls[namespace].complex_types[type_name]
             except KeyError:
-                raise KeyError('ComplexType {} does not exist in Schema Namespace {}'.format(type_name, namespace))
+                raise KeyError(f'ComplexType {type_name} does not exist in Schema Namespace {namespace}')
 
         for decl in list(self._decls.values()):
             try:
@@ -892,7 +892,7 @@ class Schema:
             except KeyError:
                 pass
 
-        raise KeyError('ComplexType {} does not exist in any Schema Namespace'.format(type_name))
+        raise KeyError(f'ComplexType {type_name} does not exist in any Schema Namespace')
 
     def enum_type(self, type_name, namespace=None):
         if namespace is not None:
@@ -912,7 +912,7 @@ class Schema:
     def get_type(self, type_info):
 
         # construct search name based on collection information
-        search_name = type_info.name if not type_info.is_collection else 'Collection({})'.format(type_info.name)
+        search_name = type_info.name if not type_info.is_collection else f'Collection({type_info.name})'
 
         # first look for type in primitive types
         try:
@@ -959,7 +959,7 @@ class Schema:
             try:
                 return self._decls[namespace].entity_sets[set_name]
             except KeyError:
-                raise KeyError('EntitySet {} does not exist in Schema Namespace {}'.format(set_name, namespace))
+                raise KeyError(f'EntitySet {set_name} does not exist in Schema Namespace {namespace}')
 
         for decl in list(self._decls.values()):
             try:
@@ -967,7 +967,7 @@ class Schema:
             except KeyError:
                 pass
 
-        raise KeyError('EntitySet {} does not exist in any Schema Namespace'.format(set_name))
+        raise KeyError(f'EntitySet {set_name} does not exist in any Schema Namespace')
 
     @property
     def entity_sets(self):
@@ -987,7 +987,7 @@ class Schema:
             except KeyError:
                 pass
 
-        raise KeyError('FunctionImport {} does not exist in any Schema Namespace'.format(function_import))
+        raise KeyError(f'FunctionImport {function_import} does not exist in any Schema Namespace')
 
     @property
     def function_imports(self):
@@ -998,7 +998,7 @@ class Schema:
             try:
                 return self._decls[namespace].associations[association_name]
             except KeyError:
-                raise KeyError('Association {} does not exist in namespace {}'.format(association_name, namespace))
+                raise KeyError(f'Association {association_name} does not exist in namespace {namespace}')
         for decl in list(self._decls.values()):
             try:
                 return decl.associations[association_name]
@@ -1028,7 +1028,7 @@ class Schema:
             try:
                 return self._decls[namespace].association_sets[set_name]
             except KeyError:
-                raise KeyError('Association set {} does not exist in namespace {}'.format(set_name, namespace))
+                raise KeyError(f'Association set {set_name} does not exist in namespace {namespace}')
         for decl in list(self._decls.values()):
             try:
                 return decl.association_sets[set_name]
@@ -1049,7 +1049,7 @@ class Schema:
             try:
                 entity_type.proprty(proprty)
             except KeyError:
-                raise PyODataModelError('Property {} does not exist in {}'.format(proprty, entity_type.name))
+                raise PyODataModelError(f'Property {proprty} does not exist in {entity_type.name}')
 
     # pylint: disable=too-many-locals,too-many-branches,too-many-statements
     @staticmethod
@@ -1149,7 +1149,7 @@ class Schema:
                         if principal_role.name not in role_names:
                             schema._is_valid = False
                             raise RuntimeError(
-                                'Role {} was not defined in association {}'.format(principal_role.name, assoc.name))
+                                f'Role {principal_role.name} was not defined in association {assoc.name}')
 
                         # Check if principal role properties exist
                         role_name = principal_role.name
@@ -1162,7 +1162,7 @@ class Schema:
                         if dependent_role.name not in role_names:
                             schema._is_valid = False
                             raise RuntimeError(
-                                'Role {} was not defined in association {}'.format(dependent_role.name, assoc.name))
+                                f'Role {dependent_role.name} was not defined in association {assoc.name}')
 
                         # Check if dependent role properties exist
                         role_name = dependent_role.name
@@ -1254,7 +1254,7 @@ class Schema:
             for annotation_group in schema_node.xpath('edm:Annotations', namespaces=ANNOTATION_NAMESPACES):
                 for annotation in ExternalAnnontation.from_etree(annotation_group):
                     if not annotation.element_namespace != schema.namespaces:
-                        modlog().warning('{0} not in the namespaces {1}'.format(annotation, ','.join(schema.namespaces)))
+                        modlog().warning(f"{annotation} not in the namespaces {','.join(schema.namespaces)}")
                         continue
 
                     try:
@@ -1329,7 +1329,7 @@ class StructType(Typ):
             stp = StructTypeProperty.from_etree(proprty)
 
             if stp.name in stype._properties:
-                raise KeyError('{0} already has property {1}'.format(stype, stp.name))
+                raise KeyError(f'{stype} already has property {stp.name}')
 
             stype._properties[stp.name] = stp
 
@@ -1509,7 +1509,7 @@ class EntityType(StructType):
             navp = NavigationTypeProperty.from_etree(proprty)
 
             if navp.name in etype._nav_properties:
-                raise KeyError('{0} already has navigation property {1}'.format(etype, navp.name))
+                raise KeyError(f'{etype} already has navigation property {navp.name}')
 
             etype._nav_properties[navp.name] = navp
 
@@ -1545,10 +1545,10 @@ class EntitySet(Identifier):
     @entity_type.setter
     def entity_type(self, value):
         if self._entity_type is not None:
-            raise RuntimeError('Cannot replace {0} of {1} to {2}'.format(self._entity_type, self, value))
+            raise RuntimeError(f'Cannot replace {self._entity_type} of {self} to {value}')
 
         if value.name != self.entity_type_info[1]:
-            raise RuntimeError('{0} cannot be the type of {1}'.format(value, self))
+            raise RuntimeError(f'{value} cannot be the type of {self}')
 
         self._entity_type = value
 
@@ -1654,7 +1654,7 @@ class StructTypeProperty(VariableDeclaration):
     def struct_type(self, value):
 
         if self._struct_type is not None:
-            raise RuntimeError('Cannot replace {0} of {1} to {2}'.format(self._struct_type, self, value))
+            raise RuntimeError(f'Cannot replace {self._struct_type} of {self} to {value}')
 
         self._struct_type = value
 
@@ -1735,7 +1735,7 @@ class StructTypeProperty(VariableDeclaration):
     def value_helper(self, value):
         # Value Help property must not be changed
         if self._value_helper is not None:
-            raise RuntimeError('Cannot replace value helper {0} of {1} by {2}'.format(self._value_helper, self, value))
+            raise RuntimeError(f'Cannot replace value helper {self._value_helper} of {self} by {value}')
 
         self._value_helper = value
 
@@ -1804,10 +1804,10 @@ class NavigationTypeProperty(VariableDeclaration):
     def association(self, value):
 
         if self._association is not None:
-            raise PyODataModelError('Cannot replace {0} of {1} to {2}'.format(self._association, self, value))
+            raise PyODataModelError(f'Cannot replace {self._association} of {self} to {value}')
 
         if value.name != self._association_info.name:
-            raise PyODataModelError('{0} cannot be the type of {1}'.format(value, self))
+            raise PyODataModelError(f'{value} cannot be the type of {self}')
 
         self._association = value
 
@@ -1838,7 +1838,7 @@ class EndRole:
         self._role = role
 
     def __repr__(self):
-        return "{0}({1})".format(self.__class__.__name__, self.role)
+        return f"{self.__class__.__name__}({self.role})"
 
     @property
     def entity_type_info(self):
@@ -1856,10 +1856,10 @@ class EndRole:
     def entity_type(self, value):
 
         if self._entity_type is not None:
-            raise PyODataModelError('Cannot replace {0} of {1} to {2}'.format(self._entity_type, self, value))
+            raise PyODataModelError(f'Cannot replace {self._entity_type} of {self} to {value}')
 
         if value.name != self._entity_type_info.name:
-            raise PyODataModelError('{0} cannot be the type of {1}'.format(value, self))
+            raise PyODataModelError(f'{value} cannot be the type of {self}')
 
         self._entity_type = value
 
@@ -1929,7 +1929,7 @@ class ReferentialConstraint:
         for property_ref in principal[0].xpath('edm:PropertyRef', namespaces=config.namespaces):
             principal_refs.append(property_ref.get('Name'))
         if not principal_refs:
-            raise RuntimeError('In role {} should be at least one principal property defined'.format(principal_name))
+            raise RuntimeError(f'In role {principal_name} should be at least one principal property defined')
 
         dependent = referential_constraint_node.xpath('edm:Dependent', namespaces=config.namespaces)
         if len(dependent) != 1:
@@ -1967,7 +1967,7 @@ class Association:
         self._end_roles = list()
 
     def __str__(self):
-        return '{0}({1})'.format(self.__class__.__name__, self._name)
+        return f'{self.__class__.__name__}({self._name})'
 
     @property
     def name(self):
@@ -1981,7 +1981,7 @@ class Association:
         try:
             return next((item for item in self._end_roles if item.role == end_role))
         except StopIteration:
-            raise KeyError('Association {} has no End with Role {}'.format(self._name, end_role))
+            raise KeyError(f'Association {self._name} has no End with Role {end_role}')
 
     @property
     def referential_constraint(self):
@@ -1995,15 +1995,15 @@ class Association:
         for end in association_node.xpath('edm:End', namespaces=config.namespaces):
             end_role = EndRole.from_etree(end)
             if end_role.entity_type_info is None:
-                raise RuntimeError('End type is not specified in the association {}'.format(name))
+                raise RuntimeError(f'End type is not specified in the association {name}')
             association._end_roles.append(end_role)
 
         if len(association._end_roles) != 2:
-            raise RuntimeError('Association {} does not have two end roles'.format(name))
+            raise RuntimeError(f'Association {name} does not have two end roles')
 
         refer = association_node.xpath('edm:ReferentialConstraint', namespaces=config.namespaces)
         if len(refer) > 1:
-            raise RuntimeError('In association {} is defined more than one referential constraint'.format(name))
+            raise RuntimeError(f'In association {name} is defined more than one referential constraint')
 
         if not refer:
             referential_constraint = None
@@ -2022,7 +2022,7 @@ class AssociationSetEndRole:
         self._entity_set = None
 
     def __repr__(self):
-        return "{0}({1})".format(self.__class__.__name__, self.role)
+        return f"{self.__class__.__name__}({self.role})"
 
     @property
     def role(self):
@@ -2039,11 +2039,11 @@ class AssociationSetEndRole:
     @entity_set.setter
     def entity_set(self, value):
         if self._entity_set:
-            raise PyODataModelError('Cannot replace {0} of {1} to {2}'.format(self._entity_set, self, value))
+            raise PyODataModelError(f'Cannot replace {self._entity_set} of {self} to {value}')
 
         if value.name != self._entity_set_name:
             raise PyODataModelError(
-                'Assigned entity set {0} differentiates from the declared {1}'.format(value, self._entity_set_name))
+                f'Assigned entity set {value} differentiates from the declared {self._entity_set_name}')
 
         self._entity_set = value
 
@@ -2064,7 +2064,7 @@ class AssociationSet:
         self._end_roles = end_roles
 
     def __str__(self):
-        return "{0}({1})".format(self.__class__.__name__, self._name)
+        return f"{self.__class__.__name__}({self._name})"
 
     @property
     def name(self):
@@ -2090,18 +2090,18 @@ class AssociationSet:
         try:
             return next((end for end in self._end_roles if end.role == end_role))
         except StopIteration:
-            raise KeyError('Association set {} has no End with Role {}'.format(self._name, end_role))
+            raise KeyError(f'Association set {self._name} has no End with Role {end_role}')
 
     def end_by_entity_set(self, entity_set):
         try:
             return next((end for end in self._end_roles if end.entity_set_name == entity_set))
         except StopIteration:
-            raise KeyError('Association set {} has no End with Entity Set {}'.format(self._name, entity_set))
+            raise KeyError(f'Association set {self._name} has no End with Entity Set {entity_set}')
 
     @association_type.setter
     def association_type(self, value):
         if self._association_type is not None:
-            raise RuntimeError('Cannot replace {} of {} with {}'.format(self._association_type, self, value))
+            raise RuntimeError(f'Cannot replace {self._association_type} of {self} with {value}')
         self._association_type = value
 
     @staticmethod
@@ -2112,7 +2112,7 @@ class AssociationSet:
 
         end_roles_list = association_set_node.xpath('edm:End', namespaces=config.namespaces)
         if len(end_roles) > 2:
-            raise PyODataModelError('Association {} cannot have more than 2 end roles'.format(name))
+            raise PyODataModelError(f'Association {name} cannot have more than 2 end roles')
 
         for end_role in end_roles_list:
             end_roles.append(AssociationSetEndRole.from_etree(end_role))
@@ -2131,7 +2131,7 @@ class Annotation:
         self._qualifier = qualifier
 
     def __str__(self):
-        return "{0}({1})".format(self.__class__.__name__, self.target)
+        return f"{self.__class__.__name__}({self.target})"
 
     @property
     def element_namespace(self):
@@ -2143,7 +2143,7 @@ class Annotation:
 
     @property
     def target(self):
-        return '{0}.{1}'.format(self._element_namespace, self._element)
+        return f'{self._element_namespace}.{self._element}'
 
     @property
     def kind(self):
@@ -2155,7 +2155,7 @@ class Annotation:
         if term in SAP_ANNOTATION_VALUE_LIST:
             return ValueHelper.from_etree(target, annotation_node)
 
-        modlog().warning('Unsupported Annotation({0})'.format(term))
+        modlog().warning(f'Unsupported Annotation({term})')
         return None
 
 
@@ -2165,7 +2165,7 @@ class ExternalAnnontation:
         target = annotations_node.get('Target')
 
         if annotations_node.get('Qualifier'):
-            modlog().warning('Ignoring qualified Annotations of {}'.format(target))
+            modlog().warning(f'Ignoring qualified Annotations of {target}')
             return
 
         for annotation in annotations_node.xpath('edm:Annotation', namespaces=ANNOTATION_NAMESPACES):
@@ -2192,7 +2192,7 @@ class ValueHelper(Annotation):
         self._parameters = list()
 
     def __str__(self):
-        return "{0}({1})".format(self.__class__.__name__, self.element)
+        return f"{self.__class__.__name__}({self.element})"
 
     @property
     def proprty_name(self):
@@ -2209,10 +2209,10 @@ class ValueHelper(Annotation):
     @proprty.setter
     def proprty(self, value):
         if self._proprty is not None:
-            raise RuntimeError('Cannot replace {0} of {1} with {2}'.format(self._proprty, self, value))
+            raise RuntimeError(f'Cannot replace {self._proprty} of {self} with {value}')
 
         if value.struct_type.name != self.proprty_entity_type_name or value.name != self.proprty_name:
-            raise RuntimeError('{0} cannot be an annotation of {1}'.format(self, value))
+            raise RuntimeError(f'{self} cannot be an annotation of {value}')
 
         self._proprty = value
 
@@ -2236,10 +2236,10 @@ class ValueHelper(Annotation):
     @entity_set.setter
     def entity_set(self, value):
         if self._entity_set is not None:
-            raise RuntimeError('Cannot replace {0} of {1} with {2}'.format(self._entity_set, self, value))
+            raise RuntimeError(f'Cannot replace {self._entity_set} of {self} with {value}')
 
         if value.name != self.collection_path:
-            raise RuntimeError('{0} cannot be assigned to {1}'.format(self, value))
+            raise RuntimeError(f'{self} cannot be assigned to {value}')
 
         self._entity_set = value
 
@@ -2265,14 +2265,14 @@ class ValueHelper(Annotation):
             if prm.local_property.name == name:
                 return prm
 
-        raise KeyError('{0} has no local property {1}'.format(self, name))
+        raise KeyError(f'{self} has no local property {name}')
 
     def list_property_param(self, name):
         for prm in self._parameters:
             if prm.list_property.name == name:
                 return prm
 
-        raise KeyError('{0} has no list property {1}'.format(self, name))
+        raise KeyError(f'{self} has no list property {name}')
 
     @staticmethod
     def from_etree(target, annotation_node):
@@ -2319,9 +2319,9 @@ class ValueHelperParameter:
 
     def __str__(self):
         if self._direction in [ValueHelperParameter.Direction.DisplayOnly, ValueHelperParameter.Direction.FilterOnly]:
-            return "{0}({1})".format(self.__class__.__name__, self._list_property_name)
+            return f"{self.__class__.__name__}({self._list_property_name})"
 
-        return "{0}({1}={2})".format(self.__class__.__name__, self._local_property_name, self._list_property_name)
+        return f"{self.__class__.__name__}({self._local_property_name}={self._list_property_name})"
 
     @property
     def value_helper(self):
@@ -2330,7 +2330,7 @@ class ValueHelperParameter:
     @value_helper.setter
     def value_helper(self, value):
         if self._value_helper is not None:
-            raise RuntimeError('Cannot replace {0} of {1} with {2}'.format(self._value_helper, self, value))
+            raise RuntimeError(f'Cannot replace {self._value_helper} of {self} with {value}')
 
         self._value_helper = value
 
@@ -2349,7 +2349,7 @@ class ValueHelperParameter:
     @local_property.setter
     def local_property(self, value):
         if self._local_property is not None:
-            raise RuntimeError('Cannot replace {0} of {1} with {2}'.format(self._local_property, self, value))
+            raise RuntimeError(f'Cannot replace {self._local_property} of {self} with {value}')
 
         self._local_property = value
 
@@ -2364,7 +2364,7 @@ class ValueHelperParameter:
     @list_property.setter
     def list_property(self, value):
         if self._list_property is not None:
-            raise RuntimeError('Cannot replace {0} of {1} with {2}'.format(self._list_property, self, value))
+            raise RuntimeError(f'Cannot replace {self._list_property} of {self} with {value}')
 
         self._list_property = value
 
@@ -2405,10 +2405,10 @@ class FunctionImport(Identifier):
     @return_type.setter
     def return_type(self, value):
         if self._return_type is not None:
-            raise RuntimeError('Cannot replace {0} of {1} by {2}'.format(self._return_type, self, value))
+            raise RuntimeError(f'Cannot replace {self._return_type} of {self} by {value}')
 
         if value.name != self.return_type_info[1]:
-            raise RuntimeError('{0} cannot be the type of {1}'.format(value, self))
+            raise RuntimeError(f'{value} cannot be the type of {self}')
 
         self._return_type = value
 
@@ -2488,7 +2488,7 @@ def str_to_bool(value, attr, default):
     if value == 'false':
         return False
 
-    raise TypeError('Not a bool attribute: {0} = {1}'.format(attr, value))
+    raise TypeError(f'Not a bool attribute: {attr} = {value}')
 
 
 def attribute_get_bool(node, attr, default):
@@ -2549,7 +2549,7 @@ class MetadataBuilder:
         elif isinstance(self._xml, bytes):
             mdf = io.BytesIO(self._xml)
         else:
-            raise TypeError('Expected bytes or str type on metadata_xml, got : {0}'.format(type(self._xml)))
+            raise TypeError(f'Expected bytes or str type on metadata_xml, got : {type(self._xml)}')
 
         namespaces = self._config.namespaces
         xml = etree.parse(mdf)

--- a/pyodata/v2/service.py
+++ b/pyodata/v2/service.py
@@ -45,7 +45,7 @@ def encode_multipart(boundary, http_requests):
 
     for req in http_requests:
 
-        lines.append('--{0}'.format(boundary))
+        lines.append(f'--{boundary}')
 
         if not isinstance(req, MultipartRequest):
             lines.extend(('Content-Type: application/http ', 'Content-Transfer-Encoding:binary'))
@@ -53,7 +53,7 @@ def encode_multipart(boundary, http_requests):
             lines.append('')
 
             # request  line (method + path + query params)
-            line = '{method} {path}'.format(method=req.get_method(), path=req.get_path())
+            line = f'{req.get_method()} {req.get_path()}'
             query_params = '&'.join(['{}={}'.format(key, val) for key, val in req.get_query_params().items()])
             if query_params:
                 line += '?' + query_params
@@ -63,7 +63,7 @@ def encode_multipart(boundary, http_requests):
 
         # request specific headers
         for hdr, hdr_val in req.get_headers().items():
-            lines.append('{}: {}'.format(hdr, hdr_val))
+            lines.append(f'{hdr}: {hdr_val}')
 
         lines.append('')
 
@@ -76,7 +76,7 @@ def encode_multipart(boundary, http_requests):
             # 400 Bad fromat from SAP gateway
             lines.append('')
 
-    lines.append('--{0}--'.format(boundary))
+    lines.append(f'--{boundary}--')
 
     return '\r\n'.join(lines)
 
@@ -96,7 +96,7 @@ def decode_multipart(data, content_type):
             messages.append(part.get_payload())
         return messages
 
-    data = "Content-Type: {}\n".format(content_type) + data
+    data = f"Content-Type: {content_type}\n" + data
     parser = Parser()
     parsed = parser.parsestr(data)
     decoded = decode(parsed)
@@ -196,7 +196,7 @@ class EntityKey:
         else:
             for key_prop in self._key:
                 if key_prop.name not in args:
-                    raise PyODataException('Missing value for key property {}'.format(key_prop.name))
+                    raise PyODataException(f'Missing value for key property {key_prop.name}')
 
             self._type = EntityKey.TYPE_COMPLEX
 
@@ -220,14 +220,14 @@ class EntityKey:
             #    raise RuntimeError('Entity key is not complete, missing value of property: {0}'.format(key_prop.name))
 
             key_pairs.append(
-                '{0}={1}'.format(key_prop.name, key_prop.to_literal(self._proprties[key_prop.name])))
+                f'{key_prop.name}={key_prop.to_literal(self._proprties[key_prop.name])}')
 
         return ','.join(key_pairs)
 
     def to_key_string(self):
         """Gets the string representation of the key, including parentheses"""
 
-        return '({})'.format(self.to_key_string_without_parentheses())
+        return f'({self.to_key_string_without_parentheses()})'
 
     def __repr__(self):
         return self.to_key_string()
@@ -292,7 +292,7 @@ class ODataHttpRequest:
         """
 
         if not isinstance(value, dict):
-            raise TypeError("Headers must be of type 'dict' not {}".format(type(value)))
+            raise TypeError(f"Headers must be of type 'dict' not {type(value)}")
 
         self._headers.update(value)
 
@@ -420,7 +420,7 @@ class NavEntityGetRequest(EntityGetRequest):
         self._nav_property = nav_property
 
     def get_path(self):
-        return "{}/{}".format(super(NavEntityGetRequest, self).get_path(), self._nav_property)
+        return f"{super(NavEntityGetRequest, self).get_path()}/{self._nav_property}"
 
 
 class EntityCreateRequest(ODataHttpRequest):
@@ -586,7 +586,7 @@ class EntityModifyRequest(ODataHttpRequest):
                 val = self._entity_type.proprty(key).to_json(val)
             except KeyError:
                 raise PyODataException(
-                    'Property {} is not declared in {} entity type'.format(key, self._entity_type.name))
+                    f'Property {key} is not declared in {self._entity_type.name} entity type')
 
             self._values[key] = val
 
@@ -858,7 +858,7 @@ class EntityProxy:
                 navigation_entity_set = self._service.schema.entity_set(end.entity_set_name, association_info.namespace)
 
         if not navigation_entity_set:
-            raise PyODataException('No association set for role {}'.format(navigation_property.to_role))
+            raise PyODataException(f'No association set for role {navigation_property.to_role}')
 
         roles = navigation_property.association.end_roles
         if all((role.multiplicity != model.EndRole.MULTIPLICITY_ZERO_OR_MORE for role in roles)):
@@ -974,7 +974,7 @@ class GetEntitySetFilter:
         if len(operands) < 2:
             raise ExpressionError('The $filter operator \'{}\' needs at least two operands'.format(operator))
 
-        return '({})'.format(' {} '.format(operator).join(operands))
+        return f"({' {} '.format(operator).join(operands)})"
 
     @staticmethod
     def and_(*operands):
@@ -992,7 +992,7 @@ class GetEntitySetFilter:
     def format_filter(proprty, operator, value):
         """Creates a filter expression """
 
-        return '{} {} {}'.format(proprty.name, operator, proprty.to_literal(value))
+        return f'{proprty.name} {operator} {proprty.to_literal(value)}'
 
     def __eq__(self, value):
         return GetEntitySetFilter.format_filter(self._proprty, 'eq', value)
@@ -1194,7 +1194,7 @@ class GetEntitySetFilterChainable:
 
         if operator == 'range':
             if not isinstance(value, (tuple, list)):
-                raise TypeError('Range must be tuple or list not {}'.format(type(value)))
+                raise TypeError(f'Range must be tuple or list not {type(value)}')
 
             if len(value) != 2:
                 raise ValueError('Only two items can be passed in a range.')
@@ -1321,7 +1321,7 @@ class EntitySetProxy:
 
         if not navigation_entity_set:
             raise PyODataException(
-                'No association set for role {} {}'.format(navigation_property.to_role, association_set.end_roles))
+                f'No association set for role {navigation_property.to_role} {association_set.end_roles}')
 
         roles = navigation_property.association.end_roles
         if all((role.multiplicity != model.EndRole.MULTIPLICITY_ZERO_OR_MORE for role in roles)):
@@ -1498,7 +1498,7 @@ class EntityContainer:
             return self._entity_sets[name]
         except KeyError:
             raise AttributeError(
-                'EntitySet {0} not defined in {1}.'.format(name, ','.join(list(self._entity_sets.keys()))))
+                f"EntitySet {name} not defined in {','.join(list(self._entity_sets.keys()))}.")
 
 
 class FunctionContainer:
@@ -1519,7 +1519,7 @@ class FunctionContainer:
 
         if name not in self._functions:
             raise AttributeError(
-                'Function {0} not defined in {1}.'.format(name, ','.join(list(self._functions.keys()))))
+                f"Function {name} not defined in {','.join(list(self._functions.keys()))}.")
 
         fimport = self._service.schema.function_import(name)
 
@@ -1742,7 +1742,7 @@ class MultipartRequest(ODataHttpRequest):
 
     def get_default_headers(self):
         # pylint: disable=no-self-use
-        return {'Content-Type': 'multipart/mixed;boundary={}'.format(self.get_boundary())}
+        return {'Content-Type': f'multipart/mixed;boundary={self.get_boundary()}'}
 
     def get_body(self):
         return encode_multipart(self.get_boundary(), self.requests)

--- a/pyodata/vendor/SAP.py
+++ b/pyodata/vendor/SAP.py
@@ -19,7 +19,7 @@ def json_get(obj, member, typ, default=None):
 
     value = obj.get(member, default)
     if not isinstance(value, typ):
-        raise ValueError('%s is not a %s' % (member, typ.__name__))
+        raise ValueError(f'{member} is not a {typ.__name__}')
 
     return value
 

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -40,7 +40,7 @@ def test_create_service_application_xml(metadata):
 
     responses.add(
         responses.GET,
-        "{0}/$metadata".format(SERVICE_URL),
+        f"{SERVICE_URL}/$metadata",
         content_type='application/xml',
         body=metadata,
         status=200)
@@ -62,7 +62,7 @@ def test_create_service_text_xml(metadata):
 
     responses.add(
         responses.GET,
-        "{0}/$metadata".format(SERVICE_URL),
+        f"{SERVICE_URL}/$metadata",
         content_type='text/xml',
         body=metadata,
         status=200)
@@ -84,7 +84,7 @@ def test_metadata_not_reachable():
 
     responses.add(
         responses.GET,
-        "{0}/$metadata".format(SERVICE_URL),
+        f"{SERVICE_URL}/$metadata",
         content_type='text/html',
         status=404)
 
@@ -99,7 +99,7 @@ def test_metadata_saml_not_authorized():
 
     responses.add(
         responses.GET,
-        "{0}/$metadata".format(SERVICE_URL),
+        f"{SERVICE_URL}/$metadata",
         content_type='text/html; charset=utf-8',
         status=200)
 
@@ -116,7 +116,7 @@ def test_client_custom_configuration(mock_warning, metadata):
 
     responses.add(
         responses.GET,
-        "{0}/$metadata".format(SERVICE_URL),
+        f"{SERVICE_URL}/$metadata",
         content_type='application/xml',
         body=metadata,
         status=200)

--- a/tests/test_service_v2.py
+++ b/tests/test_service_v2.py
@@ -32,7 +32,7 @@ def test_create_entity(service):
 
     responses.add(
         responses.POST,
-        "{0}/MasterEntities".format(service.url),
+        f"{service.url}/MasterEntities",
         headers={
             'Content-type': 'application/json',
             'ETag':  'W/\"J0FtZXJpY2FuIEFpcmxpbmVzJw==\"'
@@ -61,7 +61,7 @@ def test_create_entity_code_201(service):
 
     responses.add(
         responses.POST,
-        "{0}/MasterEntities".format(service.url),
+        f"{service.url}/MasterEntities",
         headers={'Content-type': 'application/json'},
         json={'d': {
             'Key': '12345',
@@ -83,7 +83,7 @@ def test_create_entity_code_400(service):
 
     responses.add(
         responses.POST,
-        "{0}/MasterEntities".format(service.url),
+        f"{service.url}/MasterEntities",
         headers={'Content-type': 'application/json'},
         json={},
         status=400)
@@ -102,7 +102,7 @@ def test_create_entity_containing_enum(service):
 
     responses.add(
         responses.POST,
-        "{0}/EnumTests".format(service.url),
+        f"{service.url}/EnumTests",
         headers={'Content-type': 'application/json'},
         json={'d': {
             'CountryOfOrigin': 'USA',
@@ -128,7 +128,7 @@ def test_create_entity_nested(service):
 
     responses.add(
         responses.POST,
-        "{0}/Cars".format(service.url),
+        f"{service.url}/Cars",
         headers={'Content-type': 'application/json'},
         json={'d': {
             'Name': 'Hadraplan',
@@ -137,7 +137,7 @@ def test_create_entity_nested(service):
 
     responses.add(
         responses.GET,
-        "{0}/Cars('Hadraplan')/IDPic/$value/".format(service.url),
+        f"{service.url}/Cars('Hadraplan')/IDPic/$value/",
         headers={'Content-type': 'application/jpeg'},
         body='DEADBEEF',
         status=200)
@@ -157,7 +157,7 @@ def test_create_entity_header_x_requested_with(service):
 
     responses.add(
         responses.POST,
-        "{0}/Cars".format(service.url),
+        f"{service.url}/Cars",
         headers={'Content-type': 'application/json'},
         json={'d': {
             'Name': 'Hadraplan',
@@ -179,7 +179,7 @@ def test_create_entity_nested_list(service):
 
     responses.add(
         responses.POST,
-        "{0}/Customers".format(service.url),
+        f"{service.url}/Customers",
         headers={'Content-type': 'application/json'},
         json={'d': {
             'Name': 'John',
@@ -203,7 +203,7 @@ def test_get_entity_property(service):
 
     responses.add(
         responses.GET,
-        "{0}/MasterEntities('12345')".format(service.url),
+        f"{service.url}/MasterEntities('12345')",
         headers={
             'ETag': 'W/\"J0FtZXJpY2FuIEFpcmxpbmVzJw==\"',
             'Content-type': 'application/json',
@@ -224,7 +224,7 @@ def test_entity_url(service):
 
     responses.add(
         responses.GET,
-        "{0}/MasterEntities('12345')".format(service.url),
+        f"{service.url}/MasterEntities('12345')",
         headers={'Content-type': 'application/json'},
         json={'d': {'Key': '12345'}},
         status=200)
@@ -241,7 +241,7 @@ def test_entity_entity_set_name(service):
 
     responses.add(
         responses.GET,
-        "{0}/MasterEntities('12345')".format(service.url),
+        f"{service.url}/MasterEntities('12345')",
         headers={'Content-type': 'application/json'},
         json={'d': {'Key': '12345'}},
         status=200)
@@ -258,7 +258,7 @@ def test_entity_key_simple(service):
 
     responses.add(
         responses.GET,
-        "{0}/MasterEntities('12345')".format(service.url),
+        f"{service.url}/MasterEntities('12345')",
         headers={'Content-type': 'application/json'},
         json={'d': {'Key': '12345'}},
         status=200)
@@ -276,7 +276,7 @@ def test_entity_key_complex(service):
 
     responses.add(
         responses.GET,
-        "{0}/TemperatureMeasurements(Sensor='sensor1',Date=datetime'2017-12-24T18:00:00')".format(service.url),
+        f"{service.url}/TemperatureMeasurements(Sensor='sensor1',Date=datetime'2017-12-24T18:00:00')",
         headers={'Content-type': 'application/json'},
         json={'d': {
             'Sensor': 'sensor1',
@@ -369,7 +369,7 @@ def test_function_import_primitive(service):
 
     responses.add(
         responses.GET,
-        "{0}/sum?A=2&B=4".format(service.url),
+        f"{service.url}/sum?A=2&B=4",
         headers={'Content-type': 'application/json'},
         json={'d': 6},
         status=200)
@@ -387,7 +387,7 @@ def test_function_import_primitive_unexpected_status_code(mock_warning, service)
 
     responses.add(
         responses.GET,
-        "{0}/sum?A=2&B=4".format(service.url),
+        f"{service.url}/sum?A=2&B=4",
         headers={'Content-type': 'application/json'},
         json={'d': 6},
         status=201)
@@ -406,7 +406,7 @@ def test_function_import_without_return_type(service):
 
     responses.add(
         responses.GET,
-        "{0}/refresh".format(service.url),
+        f"{service.url}/refresh",
         status=204)
 
     result = service.functions.refresh.execute()
@@ -422,7 +422,7 @@ def test_function_import_without_return_type_wrong_code(mock_warning, service):
 
     responses.add(
         responses.GET,
-        "{0}/refresh".format(service.url),
+        f"{service.url}/refresh",
         status=200)
 
     result = service.functions.refresh.execute()
@@ -442,7 +442,7 @@ def test_function_import_without_return_type_wrong_code(mock_warning, service):
 
     responses.add(
         responses.GET,
-        "{0}/refresh".format(service.url),
+        f"{service.url}/refresh",
         body=b'unexpected',
         status=204)
 
@@ -462,7 +462,7 @@ def test_function_import_http_redirect(service):
 
     responses.add(
         responses.GET,
-        "{0}/refresh".format(service.url),
+        f"{service.url}/refresh",
         status=300)
 
     with pytest.raises(HttpError) as caught:
@@ -479,7 +479,7 @@ def test_function_import_http_bad_request(service):
 
     responses.add(
         responses.GET,
-        "{0}/refresh".format(service.url),
+        f"{service.url}/refresh",
         status=400)
 
     with pytest.raises(HttpError) as caught:
@@ -496,7 +496,7 @@ def test_function_import_http_sever_error(service):
 
     responses.add(
         responses.GET,
-        "{0}/refresh".format(service.url),
+        f"{service.url}/refresh",
         status=500)
 
     with pytest.raises(HttpError) as caught:
@@ -513,7 +513,7 @@ def test_function_import_http_not_authorized(service):
 
     responses.add(
         responses.GET,
-        "{0}/refresh".format(service.url),
+        f"{service.url}/refresh",
         status=401)
 
     with pytest.raises(HttpError) as caught:
@@ -530,7 +530,7 @@ def test_function_import_http_forbidden(service):
 
     responses.add(
         responses.GET,
-        "{0}/refresh".format(service.url),
+        f"{service.url}/refresh",
         status=403)
 
     with pytest.raises(HttpError) as caught:
@@ -547,7 +547,7 @@ def test_function_import_http_forbidden(service):
 
     responses.add(
         responses.GET,
-        "{0}/refresh".format(service.url),
+        f"{service.url}/refresh",
         status=405)
 
     with pytest.raises(HttpError) as caught:
@@ -564,7 +564,7 @@ def test_function_import_entity(service):
 
     responses.add(
         responses.GET,
-        '{0}/get_max'.format(service.url),
+        f'{service.url}/get_max',
         headers={'Content-type': 'application/json'},
         json={'d': {
             'Sensor': 'Sensor-address',
@@ -587,7 +587,7 @@ def test_update_entity(service):
 
     responses.add(
         responses.PATCH,
-        "{0}/TemperatureMeasurements(Sensor='sensor1',Date=datetime'2017-12-24T18:00:00')".format(service.url),
+        f"{service.url}/TemperatureMeasurements(Sensor='sensor1',Date=datetime'2017-12-24T18:00:00')",
         json={'d': {
             'Sensor': 'Sensor-address',
             'Date': "/Date(1714138400000)/",
@@ -845,7 +845,7 @@ def test_get_entities(service):
 
     responses.add(
         responses.GET,
-        "{0}/Employees".format(service.url),
+        f"{service.url}/Employees",
         json={'d': {
             'results': [
                 {
@@ -874,7 +874,7 @@ def test_navigation_multi(service):
 
     responses.add(
         responses.GET,
-        "{0}/Employees(23)/Addresses".format(service.url),
+        f"{service.url}/Employees(23)/Addresses",
         json={'d': {
             'results': [
                 {
@@ -918,7 +918,7 @@ def test_navigation(service):
 
     responses.add(
         responses.GET,
-        "{0}/Employees(23)/Addresses(456)".format(service.url),
+        f"{service.url}/Employees(23)/Addresses(456)",
         json={'d': {
             'ID': 456,
             'Street': 'Baker Street',
@@ -944,7 +944,7 @@ def test_navigation_1on1(service):
 
     responses.add(
         responses.GET,
-        "{0}/Cars('Hadraplan')/IDPic".format(service.url),
+        f"{service.url}/Cars('Hadraplan')/IDPic",
         headers={'Content-type': 'application/json'},
         json = { 'd': {
             'CarName': 'Hadraplan',
@@ -974,7 +974,7 @@ def test_navigation_1on1_get_value_without_proxy(service):
 
     responses.add(
         responses.GET,
-        "{0}/Cars('Hadraplan')/IDPic/$value/".format(service.url),
+        f"{service.url}/Cars('Hadraplan')/IDPic/$value/",
         headers={'Content-type': 'application/jpeg'},
         body='DEADBEAF',
         status=200)
@@ -996,7 +996,7 @@ def test_navigation_when_nes_in_another_ns(service):
 
     responses.add(
         responses.GET,
-        "{0}/Customers('Mammon')/Orders".format(service.url),
+        f"{service.url}/Customers('Mammon')/Orders",
         json={'d': {'results' : [{
             'Number': '456',
             'Owner': 'Mammon',
@@ -1023,7 +1023,7 @@ def test_entity_get_value_1on1_with_proxy(service):
 
     responses.add(
         responses.GET,
-        "{0}/Cars('Hadraplan')/IDPic".format(service.url),
+        f"{service.url}/Cars('Hadraplan')/IDPic",
         headers={'Content-type': 'application/json'},
         json = { 'd': {
             'CarName': 'Hadraplan',
@@ -1034,7 +1034,7 @@ def test_entity_get_value_1on1_with_proxy(service):
 
     responses.add(
         responses.GET,
-        "{0}/Cars('Hadraplan')/IDPic/$value/".format(service.url),
+        f"{service.url}/Cars('Hadraplan')/IDPic/$value/",
         headers={'Content-type': 'application/jpeg'},
         body='DEADBEAF',
         status=200)
@@ -1054,7 +1054,7 @@ def test_entity_get_value_without_proxy(service):
 
     responses.add(
         responses.GET,
-        "{0}/CarIDPics('Hadraplan')/$value/".format(service.url),
+        f"{service.url}/CarIDPics('Hadraplan')/$value/",
         headers={'Content-type': 'application/jpeg'},
         body='DEADBEAF',
         status=200)
@@ -1074,7 +1074,7 @@ def test_entity_get_value_with_proxy(service):
 
     responses.add(
         responses.GET,
-        "{0}/CarIDPics('Hadraplan')".format(service.url),
+        f"{service.url}/CarIDPics('Hadraplan')",
         headers={'Content-type': 'application/json'},
         json = { 'd': {
             'CarName': 'Hadraplan',
@@ -1085,7 +1085,7 @@ def test_entity_get_value_with_proxy(service):
 
     responses.add(
         responses.GET,
-        "{0}/CarIDPics('Hadraplan')/$value/".format(service.url),
+        f"{service.url}/CarIDPics('Hadraplan')/$value/",
         headers={'Content-type': 'application/jpeg'},
         body='DEADBEAF',
         status=200)
@@ -1105,7 +1105,7 @@ def test_entity_get_value_without_proxy_error(service):
 
     responses.add(
         responses.GET,
-        "{0}/CarIDPics('Hadraplan')/$value/".format(service.url),
+        f"{service.url}/CarIDPics('Hadraplan')/$value/",
         headers={'Content-type': 'text/plain'},
         body='Internal Server Error',
         status=500)
@@ -1125,7 +1125,7 @@ def test_navigation_create_entity(service):
 
     responses.add(
         responses.POST,
-        "{0}/Employees(23)/Addresses".format(service.url),
+        f"{service.url}/Employees(23)/Addresses",
         json={'d': {
             'ID': 42,
             'Street': 'Holandska',
@@ -1155,7 +1155,7 @@ def test_navigation_from_entity_multi(service):
 
     responses.add(
         responses.GET,
-        "{0}/Employees(23)".format(service.url),
+        f"{service.url}/Employees(23)",
         json={'d': {
             'ID': 23,
             'NameFirst': 'Rob',
@@ -1165,7 +1165,7 @@ def test_navigation_from_entity_multi(service):
 
     responses.add(
         responses.GET,
-        "{0}/Employees(23)/Addresses".format(service.url),
+        f"{service.url}/Employees(23)/Addresses",
         json={'d': {
             'results': [
                 {
@@ -1215,7 +1215,7 @@ def test_navigation_from_entity(service):
 
     responses.add(
         responses.GET,
-        "{0}/Employees(23)".format(service.url),
+        f"{service.url}/Employees(23)",
         json={'d': {
             'ID': 23,
             'NameFirst': 'Rob',
@@ -1225,7 +1225,7 @@ def test_navigation_from_entity(service):
 
     responses.add(
         responses.GET,
-        "{0}/Employees(23)/Addresses(456)".format(service.url),
+        f"{service.url}/Employees(23)/Addresses(456)",
         json={'d': {
             'ID': 456,
             'Street': 'Baker Street',
@@ -1258,7 +1258,7 @@ def test_get_entity(service):
 
     responses.add(
         responses.GET,
-        "{0}/Employees(23)".format(service.url),
+        f"{service.url}/Employees(23)",
         json={'d': {
             'ID': 23,
             'NameFirst': 'Rob',
@@ -1284,7 +1284,7 @@ def test_get_entity_expanded(service):
 
     responses.add(
         responses.GET,
-        "{0}/Employees(23)".format(service.url),
+        f"{service.url}/Employees(23)",
         json={'d': {
             'ID': 23,
             'NameFirst': 'Rob',
@@ -1348,7 +1348,7 @@ def test_batch_request(service):
 
     responses.add(
         responses.POST,
-        '{0}/$batch'.format(URL_ROOT),
+        f'{URL_ROOT}/$batch',
         body=response_body,
         content_type='multipart/mixed; boundary=batch_r1',
         status=202)
@@ -1392,7 +1392,7 @@ def test_enormous_batch_request(service):
 
     responses.add(
         responses.POST,
-        '{0}/$batch'.format(URL_ROOT),
+        f'{URL_ROOT}/$batch',
         body=response_body,
         content_type='multipart/mixed; boundary=16804F9C063D8720EACA19F7DFB3CD4A0',
         status=202)
@@ -1427,7 +1427,7 @@ def test_batch_request_failed_changeset(service):
 
     responses.add(
         responses.POST,
-        '{0}/$batch'.format(URL_ROOT),
+        f'{URL_ROOT}/$batch',
         body=response_body,
         content_type='multipart/mixed; boundary=batch_r1',
         status=202)
@@ -1629,7 +1629,7 @@ def test_inlinecount(service):
 
     responses.add(
         responses.GET,
-        "{0}/Employees?$inlinecount=allpages".format(service.url),
+        f"{service.url}/Employees?$inlinecount=allpages",
         json={'d': {
             '__count': 3,
             'results': [
@@ -1665,7 +1665,7 @@ def test_inlinecount_with_skip(service):
 
     responses.add(
         responses.GET,
-        "{0}/Employees?$inlinecount=allpages&$skip=1".format(service.url),
+        f"{service.url}/Employees?$inlinecount=allpages&$skip=1",
         json={'d': {
             '__count': 3,
             'results': [
@@ -1697,7 +1697,7 @@ def test_navigation_inlinecount(service):
 
     responses.add(
         responses.GET,
-        "{0}/Employees(23)/Addresses?$inlinecount=allpages".format(service.url),
+        f"{service.url}/Employees(23)/Addresses?$inlinecount=allpages",
         json={'d': {
             '__count': 3,
             'results': [
@@ -1734,7 +1734,7 @@ def test_inlinecount_with_filter(service):
 
     responses.add(
         responses.GET,
-        "{0}/Employees(23)/Addresses?$inlinecount=allpages&%24filter=City%20eq%20%27London%27".format(service.url),
+        f"{service.url}/Employees(23)/Addresses?$inlinecount=allpages&%24filter=City%20eq%20%27London%27",
         json={'d': {
             '__count': 2,
             'results': [
@@ -1767,7 +1767,7 @@ def test_total_count_exception(service):
 
     responses.add(
         responses.GET,
-        "{0}/Employees".format(service.url),
+        f"{service.url}/Employees",
         json={'d': {
             'results': [
                 {
@@ -1806,7 +1806,7 @@ def test_count(service):
 
     responses.add(
         responses.GET,
-        "{0}/Employees/$count".format(service.url),
+        f"{service.url}/Employees/$count",
         json=23,
         status=200)
 
@@ -1825,7 +1825,7 @@ def test_count_with_skip(service):
 
     responses.add(
         responses.GET,
-        "{0}/Employees/$count?$skip=12".format(service.url),
+        f"{service.url}/Employees/$count?$skip=12",
         json=11,
         status=200)
 
@@ -1844,7 +1844,7 @@ def test_navigation_count(service):
 
     responses.add(
         responses.GET,
-        "{0}/Employees(23)/Addresses/$count".format(service.url),
+        f"{service.url}/Employees(23)/Addresses/$count",
         json=458,
         status=200)
 
@@ -1864,7 +1864,7 @@ def test_count_with_filter(service):
 
     responses.add(
         responses.GET,
-        "{0}/Employees(23)/Addresses/$count?%24filter=City%20eq%20%27London%27".format(service.url),
+        f"{service.url}/Employees(23)/Addresses/$count?%24filter=City%20eq%20%27London%27",
         json=3,
         status=200)
 
@@ -1884,7 +1884,7 @@ def test_count_with_chainable_filter(service):
 
     responses.add(
         responses.GET,
-        "{0}/Employees(23)/Addresses/$count?%24filter=City%20eq%20%27London%27".format(service.url),
+        f"{service.url}/Employees(23)/Addresses/$count?%24filter=City%20eq%20%27London%27",
         json=3,
         status=200)
 
@@ -1904,7 +1904,7 @@ def test_count_with_chainable_filter_lt_operator(service):
 
     responses.add(
         responses.GET,
-        "{0}/Employees/$count?%24filter=ID%20lt%2023".format(service.url),
+        f"{service.url}/Employees/$count?%24filter=ID%20lt%2023",
         json=3,
         status=200)
 
@@ -1924,7 +1924,7 @@ def test_count_with_chainable_filter_lte_operator(service):
 
     responses.add(
         responses.GET,
-        "{0}/Employees/$count?%24filter=ID%20le%2023".format(service.url),
+        f"{service.url}/Employees/$count?%24filter=ID%20le%2023",
         json=3,
         status=200)
 
@@ -1944,7 +1944,7 @@ def test_count_with_chainable_filter_gt_operator(service):
 
     responses.add(
         responses.GET,
-        "{0}/Employees/$count?%24filter=ID%20gt%2023".format(service.url),
+        f"{service.url}/Employees/$count?%24filter=ID%20gt%2023",
         json=3,
         status=200)
 
@@ -1964,7 +1964,7 @@ def test_count_with_chainable_filter_gte_operator(service):
 
     responses.add(
         responses.GET,
-        "{0}/Employees/$count?%24filter=ID%20ge%2023".format(service.url),
+        f"{service.url}/Employees/$count?%24filter=ID%20ge%2023",
         json=3,
         status=200)
 
@@ -1984,7 +1984,7 @@ def test_count_with_chainable_filter_eq_operator(service):
 
     responses.add(
         responses.GET,
-        "{0}/Employees/$count?%24filter=ID%20eq%2023".format(service.url),
+        f"{service.url}/Employees/$count?%24filter=ID%20eq%2023",
         json=3,
         status=200)
 
@@ -2004,7 +2004,7 @@ def test_count_with_chainable_filter_in_operator(service):
 
     responses.add(
         responses.GET,
-        "{0}/Employees/$count?$filter=ID%20eq%201%20or%20ID%20eq%202%20or%20ID%20eq%203".format(service.url),
+        f"{service.url}/Employees/$count?$filter=ID%20eq%201%20or%20ID%20eq%202%20or%20ID%20eq%203",
         json=3,
         status=200)
 
@@ -2024,7 +2024,7 @@ def test_count_with_chainable_filter_startswith_operator(service):
 
     responses.add(
         responses.GET,
-        "{0}/Employees/$count?$filter=startswith%28NickName%2C%20%27Tim%27%29%20eq%20true".format(service.url),
+        f"{service.url}/Employees/$count?$filter=startswith%28NickName%2C%20%27Tim%27%29%20eq%20true",
         json=3,
         status=200)
 
@@ -2044,7 +2044,7 @@ def test_count_with_chainable_filter_endswith_operator(service):
 
     responses.add(
         responses.GET,
-        "{0}/Employees/$count?$filter=endswith%28NickName%2C%20%27othy%27%29%20eq%20true".format(service.url),
+        f"{service.url}/Employees/$count?$filter=endswith%28NickName%2C%20%27othy%27%29%20eq%20true",
         json=3,
         status=200)
 
@@ -2064,7 +2064,7 @@ def test_count_with_chainable_filter_length_operator(service):
 
     responses.add(
         responses.GET,
-        "{0}/Employees/$count?$filter=length%28NickName%29%20eq%206".format(service.url),
+        f"{service.url}/Employees/$count?$filter=length%28NickName%29%20eq%206",
         json=3,
         status=200)
 
@@ -2084,7 +2084,7 @@ def test_count_with_chainable_filter_length_operator_as_string(service):
 
     responses.add(
         responses.GET,
-        "{0}/Employees/$count?$filter=length%28NickName%29%20eq%206".format(service.url),
+        f"{service.url}/Employees/$count?$filter=length%28NickName%29%20eq%206",
         json=3,
         status=200)
 
@@ -2104,7 +2104,7 @@ def test_count_with_chainable_filter_contains_operator(service):
 
     responses.add(
         responses.GET,
-        "{0}/Employees/$count?$filter=substringof%28%27Tim%27%2C%20NickName%29%20eq%20true".format(service.url),
+        f"{service.url}/Employees/$count?$filter=substringof%28%27Tim%27%2C%20NickName%29%20eq%20true",
         json=3,
         status=200)
 
@@ -2124,7 +2124,7 @@ def test_count_with_chainable_filter_range_operator(service):
 
     responses.add(
         responses.GET,
-        "{0}/Employees/$count?$filter=ID%20gte%2020%20and%20ID%20lte%2050".format(service.url),
+        f"{service.url}/Employees/$count?$filter=ID%20gte%2020%20and%20ID%20lte%2050",
         json=3,
         status=200)
 
@@ -2144,7 +2144,7 @@ def test_count_with_chainable_filter_multiple(service):
 
     responses.add(
         responses.GET,
-        "{0}/Employees/$count?%24filter=ID%20eq%2023%20and%20NickName%20eq%20%27Steve%27".format(service.url),
+        f"{service.url}/Employees/$count?%24filter=ID%20eq%2023%20and%20NickName%20eq%20%27Steve%27",
         json=3,
         status=200)
 
@@ -2164,7 +2164,7 @@ def test_count_with_chainable_filter_or(service):
 
     responses.add(
         responses.GET,
-        "{0}/Employees/$count?$filter=%28ID%20eq%2023%20and%20NickName%20eq%20%27Steve%27%29%20or%20%28ID%20eq%2025%20and%20NickName%20eq%20%27Tim%27%29".format(service.url),
+        f"{service.url}/Employees/$count?$filter=%28ID%20eq%2023%20and%20NickName%20eq%20%27Steve%27%29%20or%20%28ID%20eq%2025%20and%20NickName%20eq%20%27Tim%27%29",
         json=3,
         status=200)
 
@@ -2183,7 +2183,7 @@ def test_count_with_multiple_chainable_filters_startswith(service):
 
     responses.add(
         responses.GET,
-        "{0}/Employees/$count?$filter=%28ID%20eq%2023%20and%20startswith%28NickName%2C%20%27Ste%27%29%20eq%20true%29%20or%20%28ID%20eq%2025%20and%20NickName%20eq%20%27Tim%27%29".format(service.url),
+        f"{service.url}/Employees/$count?$filter=%28ID%20eq%2023%20and%20startswith%28NickName%2C%20%27Ste%27%29%20eq%20true%29%20or%20%28ID%20eq%2025%20and%20NickName%20eq%20%27Tim%27%29",
         json=3,
         status=200)
 
@@ -2227,7 +2227,7 @@ def test_count_with_chained_filters(service):
 
     responses.add(
         responses.GET,
-        "{0}/Employees/$count?$filter=ID%20gte%2020%20and%20ID%20lte%2050%20and%20NickName%20eq%20%27Tim%27".format(service.url),
+        f"{service.url}/Employees/$count?$filter=ID%20gte%2020%20and%20ID%20lte%2050%20and%20NickName%20eq%20%27Tim%27",
         json=3,
         status=200)
 
@@ -2266,7 +2266,7 @@ def test_create_entity_with_datetime(service):
 
     responses.add(
         responses.POST,
-        "{0}/TemperatureMeasurements".format(service.url),
+        f"{service.url}/TemperatureMeasurements",
         headers={'Content-type': 'application/json'},
         json={'d': {
             'Sensor': 'Sensor1',
@@ -2297,7 +2297,7 @@ def test_parsing_of_datetime_before_unix_time(service):
 
     responses.add(
         responses.POST,
-        "{0}/TemperatureMeasurements".format(service.url),
+        f"{service.url}/TemperatureMeasurements",
         headers={'Content-type': 'application/json'},
         json={'d': {
             'Sensor': 'Sensor1',
@@ -2324,7 +2324,7 @@ def test_mismatched_etags_in_body_and_header(service):
 
     responses.add(
         responses.POST,
-        "{0}/MasterEntities".format(service.url),
+        f"{service.url}/MasterEntities",
         headers={
             'Content-type': 'application/json',
             'ETag':  'W/\"JEF\"'
@@ -2365,7 +2365,7 @@ def test_custom_with_get_entity(service):
 
     responses.add(
         responses.GET,
-        "{0}/MasterEntities('12345')?foo=bar".format(service.url),
+        f"{service.url}/MasterEntities('12345')?foo=bar",
         headers={'Content-type': 'application/json'},
         json={'d': {'Key': '12345'}},
         status=200)

--- a/tests/test_vendor_microsoft.py
+++ b/tests/test_vendor_microsoft.py
@@ -35,7 +35,7 @@ def test_get_entities_with_top_and_skip_without_results_member(service_northwind
 
     responses.add(
         responses.GET,
-        "{0}/Employees?$skip=10&$top=5".format(service_northwind_v2.url),
+        f"{service_northwind_v2.url}/Employees?$skip=10&$top=5",
         json={'d': [
                 {
                     'EmployeeID': 1,


### PR DESCRIPTION
Because we have minimal Python version listed as 3.6, we can safely move to PEP 498 -- Literal String Interpolation.

f-strings are less verbose, more powerful (it is expression, e.g. can call functions) and quicker than old school string formatters. 

Converted using https://github.com/ikamensh/flynt