### PR TITLE
Fix versions of linters

### DIFF
--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -3,8 +3,8 @@ pytest>=4.6.0
 responses>=0.8.1
 setuptools>=38.2.4
 setuptools-scm>=1.15.6
-pylint
-pytest-cov
-codecov
-flake8
+pylint==2.6.2
+pytest-cov==2.11.1
+codecov==2.1.11
+flake8==3.8.4
 sphinx


### PR DESCRIPTION
Builds for PRs are failing with linter checks unrelated to the PR itself, when also upgrade of package happens. This is not convenient for anyone wanting to fix something.