### PR TITLE
Observer for http requests

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -20,7 +20,7 @@
 # -- Project information -----------------------------------------------------
 
 project = 'PyOData'
-copyright = '2019 SAP SE or an SAP affiliate company'
+copyright = '2021 SAP SE or an SAP affiliate company'
 author = 'SAP'
 
 # The short X.Y version

--- a/docs/usage/advanced.rst
+++ b/docs/usage/advanced.rst
@@ -95,3 +95,42 @@ it is enough to set log level to the desired value.
     logging.basicConfig()
     root_logger = logging.getLogger()
     root_logger.setLevel(logging.DEBUG)
+
+Observing HTTP traffic
+----------------------
+
+There are cases where you need access to the transport protocol (http). For
+example: you need to read value of specific http header. Pyodata provides
+simple mechanism to observe all http requests and access low level properties
+from underlying network library (e.g. **python requests**).
+
+You can use basic predefined observer class
+``pyodata.utils.RequestObserverLastCall`` to catch last response headers:
+
+.. code-block:: python
+
+    from pyodata.utils import RequestObserverLastCall
+
+    last = RequestObserverLastCall()
+    northwind.entity_sets.Employees.get_entity(1).execute(last)
+    print(last.response.headers)
+
+You can also write your own observer to cover more specific cases. This is an example of
+custom observer which stores status code of the last response.
+
+.. code-block:: python
+
+    from pyodata.utils import RequestObserver
+
+    class CatchStatusCode(RequestObserver):
+
+        def __init__(self):
+            self.status_code = None
+
+        def http_response(self, response, request):
+            self.status_code = response.status_code
+
+    last_status = RequestObserverLastCall()
+
+    northwind.entity_sets.Employees.get_entity(1).execute(last_status)
+    print(last_status.status_code)

--- a/pyodata/utils/__init__.py
+++ b/pyodata/utils/__init__.py
@@ -1,0 +1,5 @@
+"""Utilities for Python OData client"""
+
+from .request_observer import RequestObserver, RequestObserverLastCall
+
+__all__ = ["RequestObserver", "RequestObserverLastCall"]

--- a/pyodata/utils/request_observer.py
+++ b/pyodata/utils/request_observer.py
@@ -1,0 +1,34 @@
+"""
+Interface for request observer, which allows to catch odata request processing details
+
+Author: Michal Nezerka <michal.nezerka@gmail.com>
+Date:   2021-05-14
+"""
+
+from abc import ABC, abstractmethod
+
+
+class RequestObserver(ABC):
+    """
+    The RequestObserver interface declares methods for observing odata request processing.
+    """
+
+    @abstractmethod
+    def http_response(self, response, request) -> None:
+        """
+        Get http response together with related http request object.
+        """
+
+
+class RequestObserverLastCall(RequestObserver):
+    """
+    The implementation of RequestObserver that stored request and response of the last call
+    """
+
+    def __init__(self):
+        self.response = None
+        self.request = None
+
+    def http_response(self, response, request):
+        self.response = response
+        self.request = request

--- a/pyodata/v2/model.py
+++ b/pyodata/v2/model.py
@@ -1018,6 +1018,8 @@ class Schema:
             except KeyError:
                 pass
 
+        raise KeyError('Association does not exist')
+
     @property
     def associations(self):
         return list(itertools.chain(*(decl.list_associations() for decl in list(self._decls.values()))))
@@ -1047,6 +1049,8 @@ class Schema:
                 return decl.association_sets[set_name]
             except KeyError:
                 pass
+
+        raise KeyError('Association set does not exist')
 
     @property
     def association_sets(self):

--- a/pyodata/v2/service.py
+++ b/pyodata/v2/service.py
@@ -22,6 +22,7 @@ except ImportError:
     from urllib2 import quote
 
 from pyodata.exceptions import HttpError, PyODataException, ExpressionError, ProgramError
+from pyodata.utils import RequestObserver
 from . import model
 
 LOGGER_NAME = 'pyodata.service'
@@ -296,7 +297,7 @@ class ODataHttpRequest:
 
         self._headers.update(value)
 
-    def execute(self):
+    def execute(self, observer: RequestObserver = None):
         """Fetches HTTP response and returns processed result
 
            Sends the query-request to the OData service, returning a client-side Enumerable for
@@ -319,6 +320,9 @@ class ODataHttpRequest:
         params = "&".join("%s=%s" % (k, v) for k, v in self.get_query_params().items())
         response = self._connection.request(
             self.get_method(), url, headers=headers, params=params, data=body)
+
+        if observer:
+            observer.http_response(response, response.request)
 
         self._logger.debug('Received response')
         self._logger.debug('  url: %s', response.url)


### PR DESCRIPTION
This change allows caller to observe technical details (e.g. headers, body, etc.) of http requests that are sent in the background of odata calls.