### PR TITLE
model: split collections in Schema class

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
+- model: split properties schema.entity_types/complex_types and their generated Collections - Petr Hanak
 
 ## [1.7.1]
 

--- a/pyodata/v2/model.py
+++ b/pyodata/v2/model.py
@@ -805,12 +805,6 @@ class Schema:
         def list_association_sets(self):
             return list(self.association_sets.values())
 
-        def list_collections_entity_types(self):
-            return list(self._collections_entity_types.values())
-
-        def list_collections_complex_types(self):
-            return list(self._collections_complex_types.values())
-
         def add_entity_type(self, etype):
             """Add new  type to the type repository as well as its collection variant"""
 

--- a/pyodata/v2/model.py
+++ b/pyodata/v2/model.py
@@ -780,9 +780,9 @@ class Schema:
             self.associations = dict()
             self.association_sets = dict()
 
-            #generated collections for ease of lookup (e.g. function import return type)
+            # generated collections for ease of lookup (e.g. function import return type)
             self._collections_entity_types = dict()
-            self._collections_complex_types = dict() #TODO
+            self._collections_complex_types = dict()  # TODO
 
         def list_entity_types(self):
             return list(self.entity_types.values())
@@ -819,7 +819,6 @@ class Schema:
             collection_type_name = f'Collection({etype.name})'
             self._collections_entity_types[collection_type_name] = Collection(etype.name, etype)
             # TODO performance memory: this is generating collection for every entity type encoutered, regardless of such collection is really used.
-
 
         def add_complex_type(self, ctype):
             """Add new complex type to the type repository as well as its collection variant"""

--- a/tests/test_model_v2.py
+++ b/tests/test_model_v2.py
@@ -135,10 +135,17 @@ def test_edmx(schema):
     assert schema.typ('MasterEntity') == schema.entity_type('MasterEntity')
     assert schema.typ('MasterEntity', namespace='EXAMPLE_SRV') == schema.entity_type('MasterEntity',
                                                                                      namespace='EXAMPLE_SRV')
+    # check that the collection of this EntityType was generated
+    assert schema.typ('Collection(MasterEntity)', namespace='EXAMPLE_SRV') == schema._collections_entity_types('Collection(MasterEntity)',
+                                                                                     namespace='EXAMPLE_SRV')
 
     # ComplexType from the method typ
     assert schema.typ('Building') == schema.complex_type('Building')
     assert schema.typ('Building', namespace='EXAMPLE_SRV') == schema.complex_type('Building', namespace='EXAMPLE_SRV')
+
+    # check that the collection of this ComplexType was generated
+    assert schema.typ('Collection(Building)', namespace='EXAMPLE_SRV') == schema._collections_complex_types(
+                                            'Collection(Building)',namespace='EXAMPLE_SRV')
 
     # Error handling in the method typ - without namespace
     with pytest.raises(KeyError) as typ_ex_info:

--- a/tests/test_model_v2.py
+++ b/tests/test_model_v2.py
@@ -349,6 +349,9 @@ def test_edmx_complex_types(schema):
     assert str(real_prop) == 'StructTypeProperty(Real)'
     assert str(real_prop.struct_type) == 'ComplexType(ComplexNumber)'
 
+    #after correct parsing, new complex type is registered in metadata schema
+    assert str(schema.typ('ComplexNumber')) == 'ComplexType(ComplexNumber)'
+    assert str(schema.typ('Collection(ComplexNumber)')) == 'Collection(ComplexNumber)'
 
 def test_edmx_complex_type_prop_vh(schema):
     """Check that value helpers work also for ComplexType properties and aliases"""

--- a/tests/test_model_v2.py
+++ b/tests/test_model_v2.py
@@ -349,7 +349,7 @@ def test_edmx_complex_types(schema):
     assert str(real_prop) == 'StructTypeProperty(Real)'
     assert str(real_prop.struct_type) == 'ComplexType(ComplexNumber)'
 
-    #after correct parsing, new complex type is registered in metadata schema
+    # after correct parsing, new complex type is registered in metadata schema
     assert str(schema.typ('ComplexNumber')) == 'ComplexType(ComplexNumber)'
     assert str(schema.typ('Collection(ComplexNumber)')) == 'Collection(ComplexNumber)'
 


### PR DESCRIPTION
model: split properties schema.entity_types/complex_types and their generated Collections 

Changed:
- data from  Schema.entity_sets are now in Schema.complex_types and Schema._collections_entity_sets 
- data from  Schema.complex_types are now in Schema.complex_types and Schema._collections_complex_types --
- update tests to better cover generated Collections inside schema parsing

Additional details:
- class Types is still containing both types and their generated collection variant, since it is static class for odata primitive types


Long explanation: 

Collections of entity types were added with focus of "get function imports working", which is main use case of pyodata. See commit 009198379 for details.

For use case of metadata validation, it is however not API user friendly to return two, different classes in one property, and also things that does not exists in the metadata XML at all. Collection of entity type is not "Entity Type". Schema class should return for entity_type property only parsed <EntityType> elements, not with generated possible return types for another elements. Otherwise it is misleading API to user, in a sense that there are things in schema.entity_type that are not present in the XML.

```
for et in service.schema.entity_types:
     print(et.name) 

EntityType(MasterEntity)
Collection(EntityType(MasterEntity))
EntityType(DataEntity)
Collection(EntityType(DataEntity))
```

Workaround for grabbing only entity types exist, but it is ugly and requires from API user deeper understanding than just "I want `schema.entity_sets` and `schema.entity_types` return similar list of respective <things> " .

```
from pyodata.v2.model import Collection 

        for et in self.pyodata.schema.entity_types:
            if not isinstance(et, Collection):
                print(et.name)
```