### PR TITLE
service: Support null (#79)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
+### Added
+- Prevent substitution of missing, nullable values - Reto Schneider
+
 ### Fixed
 - Fix Increased robustness when schema with empty properties is returned
 - Use valid default value for Edm.DateTimeOffset - Reto Schneider

--- a/docs/usage/initialization.rst
+++ b/docs/usage/initialization.rst
@@ -164,6 +164,30 @@ Additionally, Schema class has Boolean atribute 'is_valid' that returns if the p
 
     northwind.schema.is_valid
 
+Prevent substitution by default values
+--------------------------------------
+
+Per default, missing properties get filled in by type specific default values. While convenient, this throws away
+the knowledge of whether a value was missing in the first place.
+To prevent this, the class config mentioned in the section above takes an additional parameter, `retain_null`.
+
+.. code-block:: python
+
+    import pyodata
+    import requests
+
+    SERVICE_URL = 'http://services.odata.org/V2/Northwind/Northwind.svc/'
+
+    northwind = pyodata.Client(SERVICE_URL, requests.Session(), config=pyodata.v2.model.Config(retain_null=True))
+
+    unknown_shipped_date = northwind.entity_sets.Orders_Qries.get_entity(OrderID=11058,
+                                                                         CompanyName='Blauer See Delikatessen').execute()
+
+    print(
+        f'Shipped date: {"unknown" if unknown_shipped_date.ShippedDate is None else unknown_shipped_date.ShippedDate}')
+
+Changing `retain_null` to `False` will print `Shipped date: 1753-01-01 00:00:00+00:00`.
+
 Set custom namespaces (Deprecated - use config instead)
 -------------------------------------------------------
 
@@ -183,4 +207,3 @@ hosted on private urls such as *customEdmxUrl.com* and *customEdmUrl.com*:
     }
 
     northwind = pyodata.Client(SERVICE_URL, requests.Session(), namespaces=namespaces)
-

--- a/pyodata/client.py
+++ b/pyodata/client.py
@@ -69,7 +69,7 @@ class Client:
 
             # create service instance based on model we have
             logger.info('Creating OData Service (version: %d)', odata_version)
-            service = pyodata.v2.service.Service(url, schema, connection)
+            service = pyodata.v2.service.Service(url, schema, connection, config=config)
 
             return service
 

--- a/pyodata/v2/model.py
+++ b/pyodata/v2/model.py
@@ -91,7 +91,8 @@ class Config:
     def __init__(self,
                  custom_error_policies=None,
                  default_error_policy=None,
-                 xml_namespaces=None):
+                 xml_namespaces=None,
+                 retain_null=False):
 
         """
         :param custom_error_policies: {ParserError: ErrorPolicy} (default None)
@@ -102,6 +103,9 @@ class Config:
                                      If custom policy is not specified for the tag, the default policy will be used.
 
         :param xml_namespaces: {str: str} (default None)
+
+        :param retain_null: bool (default False)
+                            If true, do not substitute missing (and null-able) values with default value.
         """
 
         self._custom_error_policy = custom_error_policies
@@ -115,6 +119,8 @@ class Config:
             xml_namespaces = {}
 
         self._namespaces = xml_namespaces
+
+        self._retain_null = retain_null
 
     def err_policy(self, error: ParserError):
         if self._custom_error_policy is None:
@@ -136,6 +142,10 @@ class Config:
     @namespaces.setter
     def namespaces(self, value: dict):
         self._namespaces = value
+
+    @property
+    def retain_null(self):
+        return self._retain_null
 
 
 class Identifier:

--- a/tests/test_service_v2.py
+++ b/tests/test_service_v2.py
@@ -9,6 +9,7 @@ from unittest.mock import patch
 import pyodata.v2.model
 import pyodata.v2.service
 from pyodata.exceptions import PyODataException, HttpError, ExpressionError, ProgramError, PyODataModelError
+from pyodata.v2 import model
 from pyodata.v2.service import EntityKey, EntityProxy, GetEntitySetFilter, ODataHttpResponse, HTTP_CODE_OK
 
 from tests.conftest import assert_request_contains_header, contents_of_fixtures_file
@@ -22,6 +23,13 @@ def service(schema):
     """Service fixture"""
     assert schema.namespaces   # this is pythonic way how to check > 0
     return pyodata.v2.service.Service(URL_ROOT, schema, requests)
+
+
+@pytest.fixture
+def service_retain_null(schema):
+    """Service fixture which keeps null values as such"""
+    assert schema.namespaces
+    return pyodata.v2.service.Service(URL_ROOT, schema, requests, model.Config(retain_null=True))
 
 
 @responses.activate
@@ -884,6 +892,88 @@ def test_get_entities(service):
     assert empls[0].ID == 669
     assert empls[0].NameFirst == 'Yennefer'
     assert empls[0].NameLast == 'De Vengerberg'
+
+
+@responses.activate
+def test_get_null_value_from_null_preserving_service(service_retain_null):
+    """Get entity with missing property value as None type"""
+
+    # pylint: disable=redefined-outer-name
+
+    responses.add(
+        responses.GET,
+        f"{service_retain_null.url}/Employees",
+        json={'d': {
+            'results': [
+                {
+                    'ID': 1337,
+                    'NameFirst': 'Neo',
+                    'NameLast': None
+                }
+            ]
+        }},
+        status=200)
+
+    request = service_retain_null.entity_sets.Employees.get_entities()
+
+    the_ones = request.execute()
+    assert the_ones[0].ID == 1337
+    assert the_ones[0].NameFirst == 'Neo'
+    assert the_ones[0].NameLast is None
+
+
+@responses.activate
+def test_get_null_value_from_non_null_preserving_service(service):
+    """Get entity with missing property value as default type"""
+
+    # pylint: disable=redefined-outer-name
+
+    responses.add(
+        responses.GET,
+        f"{service.url}/Employees",
+        json={'d': {
+            'results': [
+                {
+                    'ID': 1337,
+                    'NameFirst': 'Neo',
+                    'NameLast': None
+                }
+            ]
+        }},
+        status=200)
+
+    request = service.entity_sets.Employees.get_entities()
+
+    the_ones = request.execute()
+    assert the_ones[0].ID == 1337
+    assert the_ones[0].NameFirst == 'Neo'
+    assert the_ones[0].NameLast == ''
+
+
+@responses.activate
+def test_get_non_nullable_value(service_retain_null):
+    """Get error when receiving a null value for a non-nullable property"""
+
+    # pylint: disable=redefined-outer-name
+
+    responses.add(
+        responses.GET,
+        f"{service_retain_null.url}/Employees",
+        json={'d': {
+            'results': [
+                {
+                    'ID': None,
+                    'NameFirst': 'Neo',
+                }
+            ]
+        }},
+        status=200)
+
+    with pytest.raises(PyODataException) as e_info:
+        service_retain_null.entity_sets.Employees.get_entities().execute()
+
+    assert str(e_info.value) == 'Value of non-nullable Property ID is null'
+
 
 @responses.activate
 def test_navigation_multi(service):


### PR DESCRIPTION
Until now, null values received from a OData server get substituted by a
default value.
Users of this library can not tell apart a value which coincidentally
equals the default, and a missing (null-ed) value received from the
server.

This commit allows the user to disable the substitution of null values by
default values, retrieving a None object instead.

Questions:
- Is this an acceptable approach to implement this features?

<s>In case the maintainers agree with the direction, I will add tests and documentation.</s> (done)