### PR TITLE
client: add application/atom+xml as valid MIME type

### DIFF
--- a/pyodata/client.py
+++ b/pyodata/client.py
@@ -22,7 +22,7 @@ def _fetch_metadata(connection, url, logger):
             f'Metadata request failed, status code: {resp.status_code}, body:\n{resp.content}', resp)
 
     mime_type = resp.headers['content-type']
-    if not any((typ in ['application/xml', 'text/xml'] for typ in mime_type.split(';'))):
+    if not any((typ in ['application/xml', 'application/atom+xml', 'text/xml'] for typ in mime_type.split(';'))):
         raise HttpError(
             f'Metadata request did not return XML, MIME type: {mime_type}, body:\n{resp.content}',
             resp)


### PR DESCRIPTION
According to Microsoft, this is an acceptable MIME type for ODATA:
https://docs.microsoft.com/en-us/openspecs/windows_protocols/ms-odata/8ee3b8ba-478c-49c1-992e-4e5ffdcd62fd

Some systems opt to use this kind of content header.