### PR TITLE
fix: more robust handling of XML EntityType Property with empty attributes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
+- Fix Increased robustness when schema with empty properties is returned
 
 ## [1.8.0]
 

--- a/pyodata/v2/model.py
+++ b/pyodata/v2/model.py
@@ -1820,7 +1820,7 @@ class StructTypeProperty(VariableDeclaration):
 
         self._struct_type = value
 
-        if self._text_proprty_name is not None:
+        if self._text_proprty_name:
             try:
                 self._text_proprty = self._struct_type.proprty(self._text_proprty_name)
             except KeyError:

--- a/tests/metadata.xml
+++ b/tests/metadata.xml
@@ -331,6 +331,14 @@
                 <Property Name="City" Type="Edm.String" Nullable="true"/>
             </EntityType>
 
+            <EntityType Name="MaterialEntityWithEmptyString">
+                <Key>
+                    <PropertyRef Name="ID"/>
+                </Key>
+                <Property Name="ID" Type="Edm.String" Nullable="false" sap:filterable="false" sap:updatable="false" sap:sortable="false"/>
+                <Property Name="Material_Type" Type="Edm.String" MaxLength="20" sap:text="" sap:updatable="false" sap:label="Material branding"/>
+            </EntityType>
+
             <Association Name="AssociationEmployeeAddress">
                 <End Type="EXAMPLE_SRV_SETS.Employee" Multiplicity="1" Role="EmployeeRole"/>
                 <End Type="EXAMPLE_SRV_SETS.Address" Multiplicity="*" Role="AddressRole"/>

--- a/tests/test_model_v2.py
+++ b/tests/test_model_v2.py
@@ -32,7 +32,8 @@ def test_edmx(schema):
         'Customer',
         'Order',
         'EnumTest',
-        'Enumeration'
+        'Enumeration',
+        'MaterialEntityWithEmptyString',
     }
 
     assert set((entity_set.name for entity_set in schema.entity_sets)) == {


### PR DESCRIPTION
If the `edmx` Schema of the Database contains empty attributes / empty strings, see updated `metadata.xml:339`, e,g.,
`<Property Name="Material_Type" Type="Edm.String" sap:text="" />`,

then `pyodata` throws an error:
`RuntimeError: The attribute sap:text of StructTypeProperty(Material_Type) is set to non existing Property `.

This fix accounts for empty attribute values, together with unit tests to test the behavior.