### PR TITLE
model: fix default Edm.DateTimeOffset value (#195)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
+### Fixed
 - Fix Increased robustness when schema with empty properties is returned
+- Use valid default value for Edm.DateTimeOffset - Reto Schneider
 
 ## [1.8.0]
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - Fix Increased robustness when schema with empty properties is returned
 - Use valid default value for Edm.DateTimeOffset - Reto Schneider
 
+### Changed
+- Adjusted Edm.DateTime default value to January 1, 1753 A.D - Reto Schneider
+
 ## [1.8.0]
 
 ### Fixed

--- a/pyodata/v2/model.py
+++ b/pyodata/v2/model.py
@@ -200,7 +200,7 @@ class Types:
             Types.register_type(Typ('Edm.String', '\'\'', EdmStringTypTraits()))
             Types.register_type(Typ('Edm.Time', 'time\'PT00H00M\''))
             Types.register_type(
-                Typ('Edm.DateTimeOffset', 'datetimeoffset\'0000-00-00T00:00:00Z\'', EdmDateTimeOffsetTypTraits()))
+                Typ('Edm.DateTimeOffset', 'datetimeoffset\'1753-01-01T00:00:00Z\'', EdmDateTimeOffsetTypTraits()))
 
     @staticmethod
     def register_type(typ):

--- a/pyodata/v2/model.py
+++ b/pyodata/v2/model.py
@@ -186,7 +186,7 @@ class Types:
             Types.register_type(Typ('Edm.Binary', 'binary\'\'', EdmBinaryTypTraits('(?:binary|X)')))
             Types.register_type(Typ('Edm.Boolean', 'false', EdmBooleanTypTraits()))
             Types.register_type(Typ('Edm.Byte', '0'))
-            Types.register_type(Typ('Edm.DateTime', 'datetime\'2000-01-01T00:00\'', EdmDateTimeTypTraits()))
+            Types.register_type(Typ('Edm.DateTime', 'datetime\'1753-01-01T00:00\'', EdmDateTimeTypTraits()))
             Types.register_type(Typ('Edm.Decimal', '0.0M'))
             Types.register_type(Typ('Edm.Double', '0.0d', EdmFPNumTypTraits.edm_double()))
             Types.register_type(Typ('Edm.Single', '0.0f', EdmFPNumTypTraits.edm_single()))

--- a/tests/test_service_v2.py
+++ b/tests/test_service_v2.py
@@ -2379,7 +2379,9 @@ def test_parsing_of_datetime_before_unix_time(service):
     ('/Date(981173106000+0001)/', datetime.datetime(2001, 2, 3, 4, 5, 6,
                                                     tzinfo=datetime.timezone(datetime.timedelta(minutes=1)))),
     ('/Date(981173106000-0001)/', datetime.datetime(2001, 2, 3, 4, 5, 6,
-                                                    tzinfo=datetime.timezone(-datetime.timedelta(minutes=1))))])
+                                                    tzinfo=datetime.timezone(-datetime.timedelta(minutes=1)))),
+    (None, datetime.datetime(1753, 1, 1, 0, 0, 0, tzinfo=datetime.timezone.utc)),
+])
 def test_parsing_of_datetimeoffset(service, json_input, expected):
     """Test DateTimeOffset handling."""
 

--- a/tests/test_service_v2.py
+++ b/tests/test_service_v2.py
@@ -2346,6 +2346,28 @@ def test_create_entity_with_naive_datetime(service):
 
 
 @responses.activate
+def test_null_datetime(service):
+    """Test default value of DateTime. Default value gets inserted when a property is null"""
+
+    responses.add(
+        responses.GET,
+        f"{service.url}/TemperatureMeasurements",
+        headers={'Content-type': 'application/json'},
+        json={'d': {
+            'results': [
+                {
+                    'Date': None,
+                }
+            ]
+        }},
+        status=200)
+
+    result = service.entity_sets.TemperatureMeasurements.get_entities().execute()
+
+    assert result[0].Date == datetime.datetime(1753, 1, 1, 0, 0, 0, tzinfo=datetime.timezone.utc)
+
+
+@responses.activate
 def test_parsing_of_datetime_before_unix_time(service):
     """Test DateTime handling of time before 1970"""
 


### PR DESCRIPTION
Default value was broken in several ways:
- Month 0 does not exist
- Day 0 does not exist
- Year 0 can not be handled by Python datetime

The new default value is copied from Edm.DateTime for consistency reasons. However, choosing something less common like 1.1.1 or 1.1.1970 might be more sensible?