### PR TITLE
model: Extract property 'FixedLength'

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Added
 - Client: Accept content type application/atom+xml - OmniTroid
+- Model: Extract property 'FixedLength' - Reto Schneider
 
 ## [1.9.0]
 

--- a/pyodata/v2/model.py
+++ b/pyodata/v2/model.py
@@ -780,7 +780,7 @@ class Collection(Typ):
 class VariableDeclaration(Identifier):
     MAXIMUM_LENGTH = -1
 
-    def __init__(self, name, type_info, nullable, max_length, precision, scale):
+    def __init__(self, name, type_info, nullable, max_length, precision, scale, fixed_length=None):
         super(VariableDeclaration, self).__init__(name)
 
         self._type_info = type_info
@@ -804,6 +804,7 @@ class VariableDeclaration(Identifier):
         else:
             self._scale = int(scale)
         self._check_scale_value()
+        self._fixed_length = bool(fixed_length)
 
     @property
     def type_info(self):
@@ -838,6 +839,10 @@ class VariableDeclaration(Identifier):
     @property
     def scale(self):
         return self._scale
+
+    @property
+    def fixed_length(self):
+        return self._fixed_length
 
     def from_literal(self, value):
         if value is None:
@@ -1797,8 +1802,9 @@ class StructTypeProperty(VariableDeclaration):
 
     # pylint: disable=too-many-locals
     def __init__(self, name, type_info, nullable, max_length, precision, scale, uncode, label, creatable, updatable,
-                 sortable, filterable, filter_restr, req_in_filter, text, visible, display_format, value_list):
-        super(StructTypeProperty, self).__init__(name, type_info, nullable, max_length, precision, scale)
+                 sortable, filterable, filter_restr, req_in_filter, text, visible, display_format, value_list,
+                 fixed_length=None):
+        super(StructTypeProperty, self).__init__(name, type_info, nullable, max_length, precision, scale, fixed_length)
 
         self._value_helper = None
         self._struct_type = None
@@ -1933,7 +1939,10 @@ class StructTypeProperty(VariableDeclaration):
             sap_attribute_get_string(entity_type_property_node, 'text'),
             sap_attribute_get_bool(entity_type_property_node, 'visible', True),
             sap_attribute_get_string(entity_type_property_node, 'display-format'),
-            sap_attribute_get_string(entity_type_property_node, 'value-list'), )
+            sap_attribute_get_string(entity_type_property_node, 'value-list'),
+            # Back to regular, non-SAP attributes.
+            attribute_get_bool(entity_type_property_node, 'FixedLength', False),
+        )
 
 
 class NavigationTypeProperty(VariableDeclaration):
@@ -1956,7 +1965,7 @@ class NavigationTypeProperty(VariableDeclaration):
     """
 
     def __init__(self, name, from_role_name, to_role_name, association_info):
-        super(NavigationTypeProperty, self).__init__(name, None, False, None, None, None)
+        super(NavigationTypeProperty, self).__init__(name, None, False, None, None, None, None)
 
         self.from_role_name = from_role_name
         self.to_role_name = to_role_name
@@ -2629,7 +2638,7 @@ class FunctionImportParameter(VariableDeclaration):
     Modes = Enum('Modes', 'In Out InOut')
 
     def __init__(self, name, type_info, nullable, max_length, precision, scale, mode):
-        super(FunctionImportParameter, self).__init__(name, type_info, nullable, max_length, precision, scale)
+        super(FunctionImportParameter, self).__init__(name, type_info, nullable, max_length, precision, scale, None)
 
         self._mode = mode
 

--- a/tests/metadata.xml
+++ b/tests/metadata.xml
@@ -105,6 +105,8 @@
                     <PropertyRef Name="Name"/>
                 </Key>
                 <Property Name="Name" Type="Edm.String" Nullable="false"/>
+                <Property Name="ID" Type="Edm.String" MaxLength="5" FixedLength="true" />
+                <Property Name="City" Type="Edm.String" MaxLength="15" FixedLength="false" />
                 <NavigationProperty Name="Orders" Relationship="EXAMPLE_SRV.CustomerOrders" FromRole="CustomerRole"
                                     ToRole="OrdersRole"/>
             </EntityType>

--- a/tests/test_model_v2.py
+++ b/tests/test_model_v2.py
@@ -171,6 +171,18 @@ def test_schema_entity_type_nullable(schema):
     assert nickname_property.nullable
 
 
+@pytest.mark.parametrize('property_name,is_fixed_length,comment', [
+    ('Name', False, 'Name has no FixedLength property, defaults to false'),
+    ('ID', True, 'Customer ID length is fixed'),
+    ('City', False, 'City names have arbitrary lengths'),
+])
+def test_schema_entity_type_fixed_length(schema, property_name, is_fixed_length, comment):
+    customer_entity = schema.entity_type('Customer')
+
+    property_ = customer_entity.proprty(property_name)
+    assert property_.fixed_length == is_fixed_length, comment
+
+
 def test_schema_entity_sets(schema):
     """Test Schema methods for EntitySets"""
 

--- a/tests/test_model_v2_EdmStructTypeSerializer.py
+++ b/tests/test_model_v2_EdmStructTypeSerializer.py
@@ -22,7 +22,7 @@ def define_complex_type(complex_type_property_declarations, nullable = True):
 
     for name, prop_decl in complex_type_property_declarations.items():
         prop = StructTypeProperty(name, prop_decl[0], nullable, None, None, None,
-            None, None, None, None, None, None, None, None, None, None, None, None)
+            None, None, None, None, None, None, None, None, None, None, None, None, None)
 
         prop.typ = Types.from_name(prop.type_info.name)
         complex_typ._properties[prop.name] = prop

--- a/tests/test_model_v2_VariableDeclaration.py
+++ b/tests/test_model_v2_VariableDeclaration.py
@@ -7,13 +7,13 @@ from pyodata.exceptions import PyODataException
 
 @pytest.fixture
 def variable_of_string_nullable():
-    variable = VariableDeclaration('TestVariable', Types.parse_type_name('Edm.String'), True, None, None, None)
+    variable = VariableDeclaration('TestVariable', Types.parse_type_name('Edm.String'), True, None, None, None, None)
     variable.typ = Types.from_name(variable.type_info.name)
     return variable
 
 @pytest.fixture
 def variable_of_string():
-    variable = VariableDeclaration('TestVariable', Types.parse_type_name('Edm.String'), False, None, None, None)
+    variable = VariableDeclaration('TestVariable', Types.parse_type_name('Edm.String'), False, None, None, None, None)
     variable.typ = Types.from_name(variable.type_info.name)
     return variable
 


### PR DESCRIPTION
Could not find any documentation on the default value if missing, but it seems is quite obvious that false, as opposed to true, is the only reasonable choice.

Please note: I have not defaulted the new parameter `fixed_length` in the `StructTypeProperty` constructor, because I got the impression that this class is not really meant to be part of the public API. Please let me know if you think otherwise.