### PR TITLE
docs: fix a NameError in querying.rst

### DIFF
--- a/docs/usage/querying.rst
+++ b/docs/usage/querying.rst
@@ -45,7 +45,7 @@ Print unique identification (Id) of all employees with name John Smith:
     smith_employees_request = northwind.entity_sets.Employees.get_entities()
     smith_employees_request = smith_employees_request.filter("FirstName eq 'John' and LastName eq 'Smith'")
 
-    for smith in smith_employees.execute():
+    for smith in smith_employees_request.execute():
         print(smith.EmployeeID)
 
 


### PR DESCRIPTION
A simple NameError when executing 'Get entities matching a filter' code. Instead of 'smith_employees', it should be 'smith_employees_request'.