### PR TITLE
service: fix navigation for associations with many to one relationships and for associations with relationships to same entity

### DIFF
--- a/pyodata/v2/service.py
+++ b/pyodata/v2/service.py
@@ -874,16 +874,10 @@ class EntityProxy:
             association_info.name,
             association_info.namespace)
 
-        navigation_entity_set = None
-        for end in association_set.end_roles:
-            if association_set.end_by_entity_set(end.entity_set_name).role == navigation_property.to_role.role:
-                navigation_entity_set = self._service.schema.entity_set(end.entity_set_name, association_info.namespace)
+        end = association_set.end_by_role(navigation_property.to_role.role)
+        navigation_entity_set = self._service.schema.entity_set(end.entity_set_name)
 
-        if not navigation_entity_set:
-            raise PyODataException(f'No association set for role {navigation_property.to_role}')
-
-        roles = navigation_property.association.end_roles
-        if all((role.multiplicity != model.EndRole.MULTIPLICITY_ZERO_OR_MORE for role in roles)):
+        if navigation_property.to_role.multiplicity != model.EndRole.MULTIPLICITY_ZERO_OR_MORE:
             return NavEntityProxy(self, nav_property, navigation_entity_set.entity_type, {})
 
         return EntitySetProxy(
@@ -1349,17 +1343,10 @@ class EntitySetProxy:
         association_set = self._service.schema.association_set_by_association(
             association_info.name)
 
-        navigation_entity_set = None
-        for end in association_set.end_roles:
-            if association_set.end_by_entity_set(end.entity_set_name).role == navigation_property.to_role.role:
-                navigation_entity_set = self._service.schema.entity_set(end.entity_set_name)
+        end = association_set.end_by_role(navigation_property.to_role.role)
+        navigation_entity_set = self._service.schema.entity_set(end.entity_set_name)
 
-        if not navigation_entity_set:
-            raise PyODataException(
-                f'No association set for role {navigation_property.to_role} {association_set.end_roles}')
-
-        roles = navigation_property.association.end_roles
-        if all((role.multiplicity != model.EndRole.MULTIPLICITY_ZERO_OR_MORE for role in roles)):
+        if navigation_property.to_role.multiplicity != model.EndRole.MULTIPLICITY_ZERO_OR_MORE:
             return self._get_nav_entity(key, nav_property, navigation_entity_set)
 
         return EntitySetProxy(

--- a/tests/metadata.xml
+++ b/tests/metadata.xml
@@ -109,6 +109,8 @@
                 <Property Name="City" Type="Edm.String" MaxLength="15" FixedLength="false" />
                 <NavigationProperty Name="Orders" Relationship="EXAMPLE_SRV.CustomerOrders" FromRole="CustomerRole"
                                     ToRole="OrdersRole"/>
+                <NavigationProperty Name="ReferredBy" Relationship="EXAMPLE_SRV.CustomerReferredBy" FromRole="CustomerRole"
+                                    ToRole="ReferredByRole"/>
             </EntityType>
 
             <EntityType Name="Order">
@@ -185,6 +187,16 @@
                         <PropertyRef Name="Owner"/>
                     </Dependent>
                 </ReferentialConstraint>
+            </Association>
+            <Association Name="CustomerReferredBy">
+                <End Type="EXAMPLE_SRV.Customer" Multiplicity="*" Role="CustomerRole"/>
+                <End Type="EXAMPLE_SRV.Customer" Multiplicity="0..1" Role="ReferredByRole"/>
+                <Principal Role="CustomerRole">
+                    <PropertyRef Name="Name"/>
+                </Principal>
+                <Dependent Role="ReferredByRole">
+                    <PropertyRef Name="Name"/>
+                </Dependent>
             </Association>
             <Association Name="toSelfMaster" sap:content-version="1">
                 <End Type="EXAMPLE_SRV.MasterEntity" Multiplicity="1" Role="FromRole_toSelfMaster"/>
@@ -394,6 +406,11 @@
                 <AssociationSet Name="CustomerOrder_AssocSet" Association="EXAMPLE_SRV.CustomerOrders">
                     <End Role="CustomerRole" EntitySet="Customers"/>
                     <End Role="OrdersRole" EntitySet="Orders"/>
+                </AssociationSet>
+
+                <AssociationSet Name="CustomerReferredBy_AssocSet" Association="EXAMPLE_SRV.CustomerReferredBy">
+                    <End Role="CustomerRole" EntitySet="Customers"/>
+                    <End Role="ReferredByRole" EntitySet="Customers"/>
                 </AssociationSet>
 
             </EntityContainer>

--- a/tests/test_model_v2.py
+++ b/tests/test_model_v2.py
@@ -214,6 +214,7 @@ def test_edmx_associations(schema):
         'toCarIDPic',
         'toDataEntity',
         'CustomerOrders',
+        'CustomerReferredBy',
         'AssociationEmployeeAddress',
         'toSelfMaster'
     }
@@ -241,6 +242,7 @@ def test_edmx_associations(schema):
         'toDataEntitySet',
         'AssociationEmployeeAddress_AssocSet',
         'CustomerOrder_AssocSet',
+        'CustomerReferredBy_AssocSet',
         'toCarIDPicSet',
         'toSelfMasterSet'
     }

--- a/tests/test_service_v2.py
+++ b/tests/test_service_v2.py
@@ -1046,6 +1046,34 @@ def test_navigation(service):
 
 
 @responses.activate
+def test_navigation_multi_on1(service):
+    """Check getting entity via navigation property"""
+
+    # pylint: disable=redefined-outer-name
+
+    responses.add(
+        responses.GET,
+        f"{service.url}/Customers('Mammon')/ReferredBy",
+        headers={'Content-type': 'application/json'},
+        json = { 'd': {
+            'Name': 'John',
+            }
+        },
+        status=200)
+
+    request = service.entity_sets.Customers.get_entity('Mammon').nav('ReferredBy')
+    assert isinstance(request, pyodata.v2.service.EntityGetRequest)
+
+    referred_by_proxy = request.execute()
+    assert isinstance(referred_by_proxy, pyodata.v2.service.NavEntityProxy)
+
+    assert referred_by_proxy.entity_set._name == 'Customers'
+    assert referred_by_proxy._entity_type.name == 'Customer'
+
+    assert referred_by_proxy.Name == 'John'
+
+
+@responses.activate
 def test_navigation_1on1(service):
     """Check getting entity via navigation property"""
 


### PR DESCRIPTION
When playing around with the [OData API of the SAP Analytics Cloud](https://api.sap.com/api/Story_API/resource) to retrieve some stories, I have noticed that the nav method did not work with many to one relationships. The SAC API specifies such an relationship between a story and users (createdByUser, a story can be created only by one user, but a user can create many stories): Either you have to specify a key for the nav method or to use the get_entities method which both not works as the target entity is not a list of entities (the entity is returned directly and not in a results array) or as an invalid url is generated (the target entity is being indexed, which does not work as it is not an list).

I have tracked down this issue down to line [886](https://github.com/SAP/python-pyodata/blob/08545ebcf9709642ebc7992af3e82c345869a1ff/pyodata/v2/service.py#L886) (and [1362](https://github.com/SAP/python-pyodata/blob/08545ebcf9709642ebc7992af3e82c345869a1ff/pyodata/v2/service.py#L1362)) where the multiplicity for all roles is checked and when the multiplicity for one of the role is "*" the check fails. Here only the multiplicity of the "ToRole" should be checked as this role is the relevant role for the navigation.

Additionally when writing a test for this case I have found another issue: It is not possible to use the nav method with associations where both ends are of the same entity type. The logic for finding the navigation_entity_set in line [877-880](https://github.com/SAP/python-pyodata/blob/08545ebcf9709642ebc7992af3e82c345869a1ff/pyodata/v2/service.py#L877-L880) (and [1352-1359](https://github.com/SAP/python-pyodata/blob/08545ebcf9709642ebc7992af3e82c345869a1ff/pyodata/v2/service.py#L1352-L1359)) is using the entity set name for finding the role in the association set: This does not work if both roles has the same entity set name. Here the method end_by_role method of the association set can be used to find the correct role (and then the correct navigation_entity_set).