### PR TITLE
service: add $format query option to requests which expects a response in the json format

### DIFF
--- a/pyodata/v2/model.py
+++ b/pyodata/v2/model.py
@@ -92,7 +92,8 @@ class Config:
                  custom_error_policies=None,
                  default_error_policy=None,
                  xml_namespaces=None,
-                 retain_null=False):
+                 retain_null=False,
+                 add_format_query_option=False):
 
         """
         :param custom_error_policies: {ParserError: ErrorPolicy} (default None)
@@ -106,6 +107,10 @@ class Config:
 
         :param retain_null: bool (default False)
                             If true, do not substitute missing (and null-able) values with default value.
+
+        :param add_format_query_option: bool (default False)
+                                        If true, the $format query option is added with the value json to all requests
+                                        which expects a response in the json format.
         """
 
         self._custom_error_policy = custom_error_policies
@@ -121,6 +126,8 @@ class Config:
         self._namespaces = xml_namespaces
 
         self._retain_null = retain_null
+
+        self._add_format_query_option = add_format_query_option
 
     def err_policy(self, error: ParserError):
         if self._custom_error_policy is None:
@@ -146,6 +153,10 @@ class Config:
     @property
     def retain_null(self):
         return self._retain_null
+
+    @property
+    def add_format_query_option(self):
+        return self._add_format_query_option
 
 
 class Identifier:


### PR DESCRIPTION
Although it seems to be part of the OData specification (https://www.odata.org/documentation/odata-version-2-0/operations/), it seems that there are OData APIs out there which ignore the Accept header which is sent by the library (like the OData API of the SAP Analytics Cloud).

As the library is relying on the responses in the JSON format (with one exception when the metadata is requested), it is not possible to use an OData API which ignores the Accept header without manually adding the $format query option to each request using the custom method.

This PR adds an optional config parameter (add_format_query_option) which makes it possible to automatically add the $format query option to all requests which expect a response in the JSON format (i.e. requests which are sending an Accept header).

By default the config parameter is set to false to not change the current behavior.

Alternatively I have (first) made a variant without a config parameter ([see here](https://github.com/Masterchen09/python-pyodata/commit/546995234e435b7104bb359a8cdd064b9d0ac58d)), where the $format query option is always added to the request...however I think it is better to opt-in this behavior instead of enforcing it in general.