### PR TITLE
pin pytest, pytest-cov, sphinx dev-requirements

### DIFF
--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -1,5 +1,5 @@
 requests>=2.28.1
-pytest>=7.1.2
+pytest==7.1.3
 pytest-aiohttp>=1.0.4
 responses>=0.21.0
 httpx>=0.23.0
@@ -7,8 +7,8 @@ respx>=0.19.2
 setuptools>=38.2.4
 setuptools-scm>=1.15.6
 pylint==2.8.3
-pytest-cov>=3.0.0
+pytest-cov==3.0.0
 codecov==2.1.11
 flake8==3.8.4
 bandit==1.7.0
-sphinx
+sphinx==5.2.1

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -6,7 +6,7 @@ httpx>=0.23.0
 respx>=0.19.2
 setuptools>=38.2.4
 setuptools-scm>=1.15.6
-pylint==2.8.3
+pylint==2.15.3
 pytest-cov==3.0.0
 codecov==2.1.11
 flake8==5.0.4

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -9,6 +9,6 @@ setuptools-scm>=1.15.6
 pylint==2.8.3
 pytest-cov==3.0.0
 codecov==2.1.11
-flake8==3.8.4
+flake8==5.0.4
 bandit==1.7.0
 sphinx==5.2.1


### PR DESCRIPTION
In PR #234, all the python 3.7 builds (but only .37) failed on flake8 step of linting.

File "/opt/hostedtoolcache/Python/3.7.14/x64/lib/python3.7/site-packages/flake8/plugins/manager.py", line 254, in _load_entrypoint_plugins
    eps = importlib_metadata.entry_points().get(self.namespace, ())
AttributeError: 'EntryPoints' object has no attribute 'get'

Most probable cause is the recent release of pytest-cov-4.0.0  and upgrades/mismatch in its transitive dependencies.  Pinning so builds at least run in same config as week ago and failing CI is not blocking PRs