### PR TITLE
Create run-with-pypy.yml

### DIFF
--- a/.github/workflows/run-with-pypy.yml
+++ b/.github/workflows/run-with-pypy.yml
@@ -23,7 +23,7 @@ jobs:
       run: sudo apt-get install -y libxml2-dev libxslt-dev
 
     - name: Set up Python ${{ matrix.python-version }}
-    - uses: actions/setup-python@v4 
+      uses: actions/setup-python@v4 
       with:
         python-version: ${{ matrix.python-version }}
 

--- a/.github/workflows/run-with-pypy.yml
+++ b/.github/workflows/run-with-pypy.yml
@@ -1,0 +1,38 @@
+name: try the package on pypy interpeter
+
+on:
+  push:
+    branches: [ master ]
+  pull_request:
+    branches: [ master ]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    continue-on-error: true
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version: ["pypy3.9"]
+        lxml-version: ["4.9.1"]
+
+    steps:
+    - uses: actions/checkout@v3
+
+    - name: Install lxml dependencies
+      run: sudo apt-get install -y libxml2-dev libxslt-dev
+
+    - name: Set up Python ${{ matrix.python-version }}
+    - uses: actions/setup-python@v4 
+      with:
+        python-version: ${{ matrix.python-version }}
+
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip
+        python -m pip install lxml==${{ matrix.lxml-version }}
+        python -m pip install -r dev-requirements.txt
+        python -m pip install -r requirements.txt
+    - name: Test
+      run: |
+        make test report-coverage


### PR DESCRIPTION
This should be "optionally passing, allowed to fail" build for pyodata on PYPY python implementation  (https://www.pypy.org/)

It is a copypaste of python-tests-compatibility.yml, but adding as another "python" version would 
1. create too much combinations that would need to be in Exclude section
2. create a build that would be mandatory to pass, which is not what is wanted.. this is in category "provide information about package compatibility" than "must pass for every PR". But then, there is no "allow_failures " as in Travis - so it remains to be decided after all tests will start passing in this environment as well.
 https://github.com/actions/toolkit/issues/146
 https://stackoverflow.com/questions/57687369/how-to-write-a-github-action-with-a-neutral-check-run-status


At the moment it setup the environment for tests correctly:
Successfully set up PyPy 7.3.9
 with Python (3.9.12)

But several tests are still failing (same four tests as in two year old tryout on travis, so definitelly a test-fix problem :) ]

```
=========================== short test summary info ============================
FAILED tests/test_service_v2.py::test_batch_request - AttributeError: '_io.By...
FAILED tests/test_service_v2.py::test_enormous_batch_request - AttributeError...
FAILED tests/test_service_v2.py::test_batch_request_failed_changeset - Attrib...
FAILED tests/test_service_v2.py::test_odata_http_response - AttributeError: '...
======================== 4 failed, 260 passed in 36.95s ========================


pyodata/v2/service.py:349: in execute
    return self._call_handler(response)
pyodata/v2/service.py:362: in _call_handler
    return self._handler(response)
/opt/hostedtoolcache/PyPy/3.9.12/x64/lib/pypy3.9/_functools.py:81: in __call__
    return self._func(*(self._args + fargs), **fkeywords)
pyodata/v2/service.py:1881: in http_response_handler
    return request.handler(request, decoded)
pyodata/v2/service.py:1783: in batch_handler
    result.append(req.handler(req, part))
pyodata/v2/service.py:1809: in changeset_handler
    response = ODataHttpResponse.from_string(parts[0])



```