### PR TITLE
Sharepoint support

### DIFF
--- a/pyodata/v2/service.py
+++ b/pyodata/v2/service.py
@@ -406,7 +406,7 @@ class EntityGetRequest(ODataHttpRequest):
         return self._entity_set_proxy.last_segment + self._entity_key.to_key_string()
 
     def get_default_headers(self):
-        return {'Accept': 'application/json'}
+        return {'Accept': 'application/json; odata=verbose'}
 
     def get_query_params(self):
         qparams = super(EntityGetRequest, self).get_query_params()
@@ -503,7 +503,7 @@ class EntityCreateRequest(ODataHttpRequest):
         return json.dumps(self._get_body())
 
     def get_default_headers(self):
-        return {'Accept': 'application/json', 'Content-Type': 'application/json', 'X-Requested-With': 'X'}
+        return {'Accept': 'application/json; odata=verbose', 'Content-Type': 'application/json', 'X-Requested-With': 'X'}
 
     @staticmethod
     def _build_values(entity_type, entity):
@@ -603,7 +603,7 @@ class EntityModifyRequest(ODataHttpRequest):
         return json.dumps(body)
 
     def get_default_headers(self):
-        return {'Accept': 'application/json', 'Content-Type': 'application/json'}
+        return {'Accept': 'application/json; odata=verbose', 'Content-Type': 'application/json'}
 
     def set(self, **kwargs):
         """Set properties to be changed."""
@@ -708,7 +708,7 @@ class QueryRequest(ODataHttpRequest):
             return {}
 
         return {
-            'Accept': 'application/json',
+            'Accept': 'application/json; odata=verbose',
         }
 
     def get_query_params(self):
@@ -771,7 +771,7 @@ class FunctionRequest(QueryRequest):
 
     def get_default_headers(self):
         return {
-            'Accept': 'application/json'
+            'Accept': 'application/json; odata=verbose'
         }
 
 
@@ -1763,7 +1763,7 @@ class Service:
             urljoin(self._url, path),
             conn,
             handler,
-            headers={'Accept': 'application/json'})
+            headers={'Accept': 'application/json; odata=verbose'})
 
     def create_batch(self, batch_id=None):
         """Create instance of OData batch request"""

--- a/pyodata/vendor/sharepoint.py
+++ b/pyodata/vendor/sharepoint.py
@@ -1,0 +1,60 @@
+from pyodata.v2.model import (
+    TypTraits,
+    Typ
+)
+from pyodata.exceptions import (
+    PyODataModelError,
+    PyODataException
+)
+import datetime
+
+
+class SPEdmDateTimeTypTraits(TypTraits):
+    """Edm.DateTime traits
+
+       Represents date and time with values ranging from 12:00:00 midnight,
+       January 1, 1753 A.D. through 11:59:59 P.M, December 9999 A.D.
+
+       Literal form:
+       datetime'yyyy-mm-ddThh:mm[:ss[.fffffff]]'
+       NOTE: Spaces are not allowed between datetime and quoted portion.
+       datetime is case-insensitive
+
+       Example 1: datetime'2000-12-12T12:00'
+       JSON has following format: /Date(1516614510000)/
+       https://blogs.sap.com/2017/01/05/date-and-time-in-sap-gateway-foundation/
+    """
+
+    def __init__(self):
+        super(SPEdmDateTimeTypTraits, self).__init__()
+
+    def to_literal(self, value):
+        """Convert python datetime representation to literal format
+
+           None: this could be done also via formatting string:
+           value.strftime('%Y-%m-%dT%H:%M:%S.%f')
+        """
+
+        if not isinstance(value, datetime.datetime):
+            raise PyODataModelError(
+                f'Cannot convert value of type {type(value)} to literal. Datetime format is required.')
+
+        if value.tzinfo != datetime.timezone.utc:
+            raise PyODataModelError('Edm.DateTime accepts only UTC')
+
+        # Sets timezone to none to avoid including timezone information in the literal form.
+        return value.isoformat()
+
+    def to_json(self, value):
+        return self.from_literal(value)
+
+    def from_json(self, value):
+        return self.from_literal(value)
+
+    def from_literal(self, value):
+
+        if value is None:
+            return None
+
+        # Note: parse_datetime_literal raises a PyODataModelError exception on invalid formats
+        return datetime.datetime.fromisoformat(value).replace(tzinfo=datetime.timezone.utc)


### PR DESCRIPTION
Add experimental support for Microsoft's odata variant that is used in Sharepoint

Minimal usage example with NTLM authentication
```python
import requests
from requests_ntlm3 import HttpNtlmAuth
import pyodata
from pyodata.vendor.sharepoint import (
    SPEdmDateTimeTypTraits
)
from pyodata.v2.model import (
    Types,
    Typ
)

Types.overwrite_type(Typ('Edm.DateTime', '1753-01-01T00:00', SPEdmDateTimeTypTraits()))

SERVICE_URL = 'https://example.com'

# Create instance of OData client
session = requests.Session()
session.auth = HttpNtlmAuth("<username>", "<password>")
client = pyodata.Client(SERVICE_URL, session)
```

Requirements for NTLM authentication
```
# Patched ntlm-auth that implements md4 because it has been removed from openssl/python
git+https://github.com/Sleipner-Motor-AS/ntlm-auth.git@520c21ac8d939bd6f4e62446dd0c4ac7ae0abf4a
requests-ntlm3
```