### PR TITLE
Encode path option get and update

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
+- Service: Encode paths with entity keys with option to disable it - linda-sap
 
 ## [1.10.1]
 

--- a/docs/usage/deleting.rst
+++ b/docs/usage/deleting.rst
@@ -47,7 +47,7 @@ or by passing the EntityKey object
 Encode OData URL Path
 -------------------------------------------
 
-By default the paths of requests are percent encoded. However if this is not what you API expects, 
+By default the paths of requests are percent encoded. However if this is not what your API expects, 
 you can disable the encoding with the variable encode_path by setting it to False.
 
 

--- a/docs/usage/deleting.rst
+++ b/docs/usage/deleting.rst
@@ -42,3 +42,15 @@ or by passing the EntityKey object
     key = EntityKey(service.schema.entity_type('Employee'), ID=23)
     request = service.entity_sets.Employees.delete_entity(key=key)
     request.execute()
+
+
+Encode OData URL Path
+-------------------------------------------
+
+By default the paths of requests are percent encoded. However if this is not what you API expects, 
+you can disable the encoding with the variable encode_path by setting it to False.
+
+
+.. code-block:: python
+
+   request = service.entity_sets.Employees.delete_entity(key=key, encode_path=False)

--- a/docs/usage/deleting.rst
+++ b/docs/usage/deleting.rst
@@ -47,7 +47,7 @@ or by passing the EntityKey object
 Encode OData URL Path
 -------------------------------------------
 
-By default the paths of requests are percent encoded. However if this is not what your API expects, 
+By default the resource paths of requests are percent encoded. However if this is not what your API expects, 
 you can disable the encoding with the variable encode_path by setting it to False.
 
 

--- a/docs/usage/querying.rst
+++ b/docs/usage/querying.rst
@@ -157,14 +157,12 @@ these parameters by the method `custom(name: str, value: str)`.
 Encode OData URL Path
 -------------------------------------------
 
-Sometimes services expect the path to be percent encoded. This can especially be important 
-when special variable types are key fields like Date type, where a ':' will appear in the path. 
-In this case you can use an optional parameter to make the request encode the path.
-Per default the variable encode_path is set to False.
+By default the paths of requests are percent encoded. However if this is not what you API expects, 
+you can disable the encoding with the variable encode_path by setting it to False.
 
 .. code-block:: python
 
-    employee = northwind.entity_sets.Employees.get_entity(1, encode_path=True).execute()
+    employee = northwind.entity_sets.Employees.get_entity(1, encode_path=False).execute()
 
 (Experimental) Query server-side paginations using the __next field
 -------------------------------------------------------------------

--- a/docs/usage/querying.rst
+++ b/docs/usage/querying.rst
@@ -157,7 +157,7 @@ these parameters by the method `custom(name: str, value: str)`.
 Encode OData URL Path
 -------------------------------------------
 
-By default the paths of requests are percent encoded. However if this is not what your API expects, 
+By default the resource paths of requests are percent encoded. However if this is not what your API expects, 
 you can disable the encoding with the variable encode_path by setting it to False.
 
 .. code-block:: python

--- a/docs/usage/querying.rst
+++ b/docs/usage/querying.rst
@@ -154,7 +154,17 @@ these parameters by the method `custom(name: str, value: str)`.
 
     employees = northwind.entity_sets.Employees.get_entities().custom('sap-client', '100').custom('$skiptoken', 'ABCD').top(10).execute() 
     
+Encode OData URL Path
+-------------------------------------------
 
+Sometimes services expect the path to be percent encoded. This can especially be important 
+when special variable types are key fields like Date type, where a ':' will appear in the path. 
+In this case you can use an optional parameter to make the request encode the path.
+Per default the variable encode_path is set to False.
+
+.. code-block:: python
+
+    employee = northwind.entity_sets.Employees.get_entity(1, encode_path=True).execute()
 
 (Experimental) Query server-side paginations using the __next field
 -------------------------------------------------------------------

--- a/docs/usage/querying.rst
+++ b/docs/usage/querying.rst
@@ -157,7 +157,7 @@ these parameters by the method `custom(name: str, value: str)`.
 Encode OData URL Path
 -------------------------------------------
 
-By default the paths of requests are percent encoded. However if this is not what you API expects, 
+By default the paths of requests are percent encoded. However if this is not what your API expects, 
 you can disable the encoding with the variable encode_path by setting it to False.
 
 .. code-block:: python

--- a/docs/usage/updating.rst
+++ b/docs/usage/updating.rst
@@ -38,7 +38,7 @@ then you can consider setting the default service's update method to *PUT*.
 Encode OData URL Path
 -------------------------------------------
 
-By default the paths of requests are percent encoded. However if this is not what your API expects, 
+By default the resource paths of requests are percent encoded. However if this is not what your API expects, 
 you can disable the encoding with the variable encode_path by setting it to False.
 
 

--- a/docs/usage/updating.rst
+++ b/docs/usage/updating.rst
@@ -38,11 +38,10 @@ then you can consider setting the default service's update method to *PUT*.
 Encode OData URL Path
 -------------------------------------------
 
-Sometimes services expect the path to be percent encoded. This can especially be important 
-when special variable types are key fields like Date type, where a ':' will appear in the path. 
-In this case you can use an optional parameter to make the request encode the path.
-Per default the variable encode_path is set to False.
+By default the paths of requests are percent encoded. However if this is not what you API expects, 
+you can disable the encoding with the variable encode_path by setting it to False.
+
 
 .. code-block:: python
 
-    update_request = northwind.entity_sets.Customers.update_entity(CustomerID='ALFKI', encode_path=True)
+    update_request = northwind.entity_sets.Customers.update_entity(CustomerID='ALFKI', encode_path=False)

--- a/docs/usage/updating.rst
+++ b/docs/usage/updating.rst
@@ -38,7 +38,7 @@ then you can consider setting the default service's update method to *PUT*.
 Encode OData URL Path
 -------------------------------------------
 
-By default the paths of requests are percent encoded. However if this is not what you API expects, 
+By default the paths of requests are percent encoded. However if this is not what your API expects, 
 you can disable the encoding with the variable encode_path by setting it to False.
 
 

--- a/docs/usage/updating.rst
+++ b/docs/usage/updating.rst
@@ -34,3 +34,15 @@ then you can consider setting the default service's update method to *PUT*.
 .. code-block:: python
 
     northwind.config['http']['update_method'] = 'PUT'
+
+Encode OData URL Path
+-------------------------------------------
+
+Sometimes services expect the path to be percent encoded. This can especially be important 
+when special variable types are key fields like Date type, where a ':' will appear in the path. 
+In this case you can use an optional parameter to make the request encode the path.
+Per default the variable encode_path is set to False.
+
+.. code-block:: python
+
+    update_request = northwind.entity_sets.Customers.update_entity(CustomerID='ALFKI', encode_path=True)

--- a/pyodata/v2/service.py
+++ b/pyodata/v2/service.py
@@ -442,10 +442,11 @@ class EntityGetRequest(ODataHttpRequest):
             urljoin(self._url, self.get_path(), '/$value'),
             connection,
             stream_handler)
-    
+
     def get_encode_path(self):
         """Getter for encode path flag"""
         return self._encode_path
+
 
 class NavEntityGetRequest(EntityGetRequest):
     """Used for GET operations of a single entity accessed via a Navigation property"""
@@ -615,7 +616,7 @@ class EntityModifyRequest(ODataHttpRequest):
 
     def get_default_headers(self):
         return {'Accept': 'application/json', 'Content-Type': 'application/json'}
-    
+
     def get_encode_path(self):
         """Getter for encode path flag"""
         return self._encode_path

--- a/pyodata/v2/service.py
+++ b/pyodata/v2/service.py
@@ -371,7 +371,7 @@ class ODataHttpRequest:
 class EntityGetRequest(ODataHttpRequest):
     """Used for GET operations of a single entity"""
 
-    def __init__(self, handler, entity_key, entity_set_proxy, encode_path=False):
+    def __init__(self, handler, entity_key, entity_set_proxy, encode_path=True):
         super(EntityGetRequest, self).__init__(entity_set_proxy.service.url, entity_set_proxy.service.connection,
                                                handler)
         self._logger = logging.getLogger(LOGGER_NAME)
@@ -406,8 +406,7 @@ class EntityGetRequest(ODataHttpRequest):
     def get_path(self):
         if self.get_encode_path():
             return quote(self._entity_set_proxy.last_segment + self._entity_key.to_key_string())
-        else:
-            return self._entity_set_proxy.last_segment + self._entity_key.to_key_string()
+        return self._entity_set_proxy.last_segment + self._entity_key.to_key_string()
 
     def get_default_headers(self):
         return {'Accept': 'application/json'}
@@ -553,16 +552,23 @@ class EntityCreateRequest(ODataHttpRequest):
 class EntityDeleteRequest(ODataHttpRequest):
     """Used for deleting entity (DELETE operations on a single entity)"""
 
-    def __init__(self, url, connection, handler, entity_set, entity_key):
+    def __init__(self, url, connection, handler, entity_set, entity_key, encode_path=True):
         super(EntityDeleteRequest, self).__init__(url, connection, handler)
         self._logger = logging.getLogger(LOGGER_NAME)
         self._entity_set = entity_set
         self._entity_key = entity_key
+        self._encode_path = encode_path
 
         self._logger.debug('New instance of EntityDeleteRequest for entity type: %s', entity_set.entity_type.name)
 
     def get_path(self):
+        if self.get_encode_path():
+            return quote(self._entity_set.name + self._entity_key.to_key_string())
         return self._entity_set.name + self._entity_key.to_key_string()
+
+    def get_encode_path(self):
+        """Getter for encode path flag"""
+        return self._encode_path
 
     def get_method(self):
         # pylint: disable=no-self-use
@@ -577,7 +583,7 @@ class EntityModifyRequest(ODataHttpRequest):
 
     ALLOWED_HTTP_METHODS = ['PATCH', 'PUT', 'MERGE']
 
-    def __init__(self, url, connection, handler, entity_set, entity_key, method="PATCH", encode_path=False):
+    def __init__(self, url, connection, handler, entity_set, entity_key, method="PATCH", encode_path=True):
         super(EntityModifyRequest, self).__init__(url, connection, handler)
         self._logger = logging.getLogger(LOGGER_NAME)
         self._entity_set = entity_set
@@ -600,8 +606,7 @@ class EntityModifyRequest(ODataHttpRequest):
     def get_path(self):
         if self.get_encode_path():
             return quote(self._entity_set.name + self._entity_key.to_key_string())
-        else:
-            return self._entity_set.name + self._entity_key.to_key_string()
+        return self._entity_set.name + self._entity_key.to_key_string()
 
     def get_method(self):
         # pylint: disable=no-self-use
@@ -1323,10 +1328,11 @@ class GetEntitySetFilterChainable:
 class GetEntitySetRequest(QueryRequest):
     """GET on EntitySet"""
 
-    def __init__(self, url, connection, handler, last_segment, entity_type):
+    def __init__(self, url, connection, handler, last_segment, entity_type, encode_path=True):
         super(GetEntitySetRequest, self).__init__(url, connection, handler, last_segment)
 
         self._entity_type = entity_type
+        self._encode_path = encode_path
 
     def __getattr__(self, name):
         proprty = self._entity_type.proprty(name)
@@ -1344,6 +1350,20 @@ class GetEntitySetRequest(QueryRequest):
             self._set_filter(str(GetEntitySetFilterChainable(self._entity_type, args, kwargs)))
 
         return self
+
+    def get_path(self):
+        if self.get_encode_path():
+            path = quote(self._last_segment)
+        else:
+            path = self._last_segment
+
+        if self._count:
+            return urljoin(path, '/$count')
+        return path
+
+    def get_encode_path(self):
+        """Getter for encode path flag"""
+        return self._encode_path
 
 
 class ListWithTotalCount(list):
@@ -1468,7 +1488,7 @@ class EntitySetProxy:
             self,
             nav_property)
 
-    def get_entity(self, key=None, encode_path=False, **args):
+    def get_entity(self, key=None, encode_path=True, **args):
         """Get entity based on provided key properties"""
 
         def get_entity_handler(response):
@@ -1492,7 +1512,7 @@ class EntitySetProxy:
 
         return EntityGetRequest(get_entity_handler, entity_key, self, encode_path=encode_path)
 
-    def get_entities(self):
+    def get_entities(self, encode_path=True):
         """Get some, potentially all entities"""
 
         def get_entities_handler(response):
@@ -1529,7 +1549,8 @@ class EntitySetProxy:
 
         entity_set_name = self._alias if self._alias is not None else self._entity_set.name
         return GetEntitySetRequest(self._service.url, self._service.connection, get_entities_handler,
-                                   self._parent_last_segment + entity_set_name, self._entity_set.entity_type)
+                                   self._parent_last_segment + entity_set_name, self._entity_set.entity_type,
+                                   encode_path=encode_path)
 
     def create_entity(self, return_code=HTTP_CODE_CREATED):
         """Creates a new entity in the given entity-set."""
@@ -1549,7 +1570,7 @@ class EntitySetProxy:
         return EntityCreateRequest(self._service.url, self._service.connection, create_entity_handler, self._entity_set,
                                    self.last_segment)
 
-    def update_entity(self, key=None, method=None, encode_path=False, **kwargs):
+    def update_entity(self, key=None, method=None, encode_path=True, **kwargs):
         """Updates an existing entity in the given entity-set."""
 
         def update_entity_handler(response):
@@ -1572,7 +1593,7 @@ class EntitySetProxy:
         return EntityModifyRequest(self._service.url, self._service.connection, update_entity_handler, self._entity_set,
                                    entity_key, method=method, encode_path=encode_path)
 
-    def delete_entity(self, key: EntityKey = None, **kwargs):
+    def delete_entity(self, key: EntityKey = None, encode_path=True, **kwargs):
         """Delete the entity"""
 
         def delete_entity_handler(response):
@@ -1589,7 +1610,7 @@ class EntitySetProxy:
             entity_key = EntityKey(self._entity_set.entity_type, key, **kwargs)
 
         return EntityDeleteRequest(self._service.url, self._service.connection, delete_entity_handler, self._entity_set,
-                                   entity_key)
+                                   entity_key, encode_path=encode_path)
 
 
 # pylint: disable=too-few-public-methods

--- a/pyodata/v2/service.py
+++ b/pyodata/v2/service.py
@@ -575,6 +575,7 @@ class EntityDeleteRequest(ODataHttpRequest):
         return 'DELETE'
 
 
+# pylint: disable=too-many-instance-attributes
 class EntityModifyRequest(ODataHttpRequest):
     """Used for modyfing entities (UPDATE/MERGE operations on a single entity)
 
@@ -582,7 +583,7 @@ class EntityModifyRequest(ODataHttpRequest):
        and get the modified entity."""
 
     ALLOWED_HTTP_METHODS = ['PATCH', 'PUT', 'MERGE']
-
+    # pylint: disable=too-many-arguments
     def __init__(self, url, connection, handler, entity_set, entity_key, method="PATCH", encode_path=True):
         super(EntityModifyRequest, self).__init__(url, connection, handler)
         self._logger = logging.getLogger(LOGGER_NAME)

--- a/pyodata/v2/service.py
+++ b/pyodata/v2/service.py
@@ -583,6 +583,7 @@ class EntityModifyRequest(ODataHttpRequest):
        and get the modified entity."""
 
     ALLOWED_HTTP_METHODS = ['PATCH', 'PUT', 'MERGE']
+
     # pylint: disable=too-many-arguments
     def __init__(self, url, connection, handler, entity_set, entity_key, method="PATCH", encode_path=True):
         super(EntityModifyRequest, self).__init__(url, connection, handler)

--- a/tests/test_service_v2.py
+++ b/tests/test_service_v2.py
@@ -4,6 +4,7 @@ import datetime
 import responses
 import requests
 import pytest
+from urllib.parse import quote
 from unittest.mock import patch
 
 import pyodata.v2.model
@@ -143,9 +144,10 @@ def test_create_entity_nested(service):
         }},
         status=201)
 
+    path = quote("Cars('Hadraplan')")
     responses.add(
         responses.GET,
-        f"{service.url}/Cars('Hadraplan')/IDPic/$value/",
+        f"{service.url}/{path}/IDPic/$value/",
         headers={'Content-type': 'application/jpeg'},
         body='DEADBEEF',
         status=200)
@@ -209,9 +211,10 @@ def test_get_entity_property(service):
 
     # pylint: disable=redefined-outer-name
 
+    path = quote("MasterEntities('12345')")
     responses.add(
         responses.GET,
-        f"{service.url}/MasterEntities('12345')",
+        f"{service.url}/{path}",
         headers={
             'ETag': 'W/\"J0FtZXJpY2FuIEFpcmxpbmVzJw==\"',
             'Content-type': 'application/json',
@@ -229,10 +232,10 @@ def test_entity_url(service):
     """Test correct build of entity url"""
 
     # pylint: disable=redefined-outer-name
-
+    path = quote("MasterEntities('12345')")
     responses.add(
         responses.GET,
-        f"{service.url}/MasterEntities('12345')",
+        f"{service.url}/{path}",
         headers={'Content-type': 'application/json'},
         json={'d': {'Key': '12345'}},
         status=200)
@@ -246,10 +249,10 @@ def test_entity_entity_set_name(service):
     """Test correct entity set name"""
 
     # pylint: disable=redefined-outer-name
-
+    path = quote("MasterEntities('12345')")
     responses.add(
         responses.GET,
-        f"{service.url}/MasterEntities('12345')",
+        f"{service.url}/{path}",
         headers={'Content-type': 'application/json'},
         json={'d': {'Key': '12345'}},
         status=200)
@@ -263,10 +266,10 @@ def test_entity_key_simple(service):
     """Test simple key of entity"""
 
     # pylint: disable=redefined-outer-name
-
+    path = quote("MasterEntities('12345')")
     responses.add(
         responses.GET,
-        f"{service.url}/MasterEntities('12345')",
+        f"{service.url}/{path}",
         headers={'Content-type': 'application/json'},
         json={'d': {'Key': '12345'}},
         status=200)
@@ -281,10 +284,10 @@ def test_entity_key_complex(service):
     """Test complex key of entity"""
 
     # pylint: disable=redefined-outer-name
-
+    path = quote("TemperatureMeasurements(Sensor='sensor1',Date=datetime'2017-12-24T18:00:00')")
     responses.add(
         responses.GET,
-        f"{service.url}/TemperatureMeasurements(Sensor='sensor1',Date=datetime'2017-12-24T18:00:00')",
+        f"{service.url}/{path}",
         headers={'Content-type': 'application/json'},
         json={'d': {
             'Sensor': 'sensor1',
@@ -611,10 +614,10 @@ def test_update_entity(service):
     """Check updating of entity properties"""
 
     # pylint: disable=redefined-outer-name
-
+    path = quote("TemperatureMeasurements(Sensor='sensor1',Date=datetime'2017-12-24T18:00:00')")
     responses.add(
         responses.PATCH,
-        f"{service.url}/TemperatureMeasurements(Sensor='sensor1',Date=datetime'2017-12-24T18:00:00')",
+        f"{service.url}/{path}",
         json={'d': {
             'Sensor': 'Sensor-address',
             'Date': "/Date(1714138400000)/",
@@ -647,8 +650,19 @@ def test_update_entity(service):
 def test_delete_entity(service):
     """Check deleting of entity"""
 
-    responses.add(responses.DELETE, f"{service.url}/Employees(23)", status=204)
+    path = quote("Employees(23)")
+    responses.add(responses.DELETE, f"{service.url}/{path}", status=204)
     request = service.entity_sets.Employees.delete_entity(23)
+
+    assert isinstance(request, pyodata.v2.service.EntityDeleteRequest)
+    assert request.execute() is None
+
+@responses.activate
+def test_delete_entity_with_decoded_path(service):
+    """Check deleting of entity"""
+
+    responses.add(responses.DELETE, f"{service.url}/Employees(23)", status=204)
+    request = service.entity_sets.Employees.delete_entity(23, encode_path=False)
 
     assert isinstance(request, pyodata.v2.service.EntityDeleteRequest)
     assert request.execute() is None
@@ -658,7 +672,8 @@ def test_delete_entity(service):
 def test_delete_entity_with_key(service):
     """Check deleting of entity with key"""
 
-    responses.add(responses.DELETE, f"{service.url}/Employees(ID=23)", status=204)
+    path = quote("Employees(ID=23)")
+    responses.add(responses.DELETE, f"{service.url}/{path}", status=204)
     key = EntityKey(service.schema.entity_type('Employee'), ID=23)
     request = service.entity_sets.Employees.delete_entity(key=key)
 
@@ -670,7 +685,8 @@ def test_delete_entity_with_key(service):
 def test_delete_entity_http_error(service):
     """Check if error is raisen when deleting unknown entity"""
 
-    responses.add(responses.DELETE, f"{service.url}/Employees(ID=23)", status=404)
+    path = quote("Employees(ID=23)")
+    responses.add(responses.DELETE, f"{service.url}/{path}", status=404)
     key = EntityKey(service.schema.entity_type('Employee'), ID=23)
     request = service.entity_sets.Employees.delete_entity(key=key)
 
@@ -695,7 +711,7 @@ def test_update_entity_with_entity_key(service):
         Date=datetime.datetime(2017, 12, 24, 18, 0, tzinfo=datetime.timezone.utc))
 
     query = service.entity_sets.TemperatureMeasurements.update_entity(key)
-    assert query.get_path() == "TemperatureMeasurements(Sensor='sensor1',Date=datetime'2017-12-24T18:00:00')"
+    assert query.get_path() == quote("TemperatureMeasurements(Sensor='sensor1',Date=datetime'2017-12-24T18:00:00')")
 
 
 def test_update_entity_with_put_method_specified(service):
@@ -980,10 +996,10 @@ def test_navigation_multi(service):
     """Get entities via navigation property"""
 
     # pylint: disable=redefined-outer-name
-
+    path = quote("Employees(23)/Addresses")
     responses.add(
         responses.GET,
-        f"{service.url}/Employees(23)/Addresses",
+        f"{service.url}/{path}",
         json={'d': {
             'results': [
                 {
@@ -1024,10 +1040,10 @@ def test_navigation(service):
     """Check getting entity via navigation property"""
 
     # pylint: disable=redefined-outer-name
-
+    path = quote("Employees(23)/Addresses(456)")
     responses.add(
         responses.GET,
-        f"{service.url}/Employees(23)/Addresses(456)",
+        f"{service.url}/{path}",
         json={'d': {
             'ID': 456,
             'Street': 'Baker Street',
@@ -1050,10 +1066,10 @@ def test_navigation_multi_on1(service):
     """Check getting entity via navigation property"""
 
     # pylint: disable=redefined-outer-name
-
+    path = quote("Customers('Mammon')/ReferredBy")
     responses.add(
         responses.GET,
-        f"{service.url}/Customers('Mammon')/ReferredBy",
+        f"{service.url}/{path}",
         headers={'Content-type': 'application/json'},
         json = { 'd': {
             'Name': 'John',
@@ -1078,10 +1094,10 @@ def test_navigation_1on1(service):
     """Check getting entity via navigation property"""
 
     # pylint: disable=redefined-outer-name
-
+    path = quote("Cars('Hadraplan')")
     responses.add(
         responses.GET,
-        f"{service.url}/Cars('Hadraplan')/IDPic",
+        f"{service.url}/{path}/IDPic",
         headers={'Content-type': 'application/json'},
         json = { 'd': {
             'CarName': 'Hadraplan',
@@ -1108,10 +1124,10 @@ def test_navigation_1on1_from_entity_proxy(service):
     """Check getting entity via navigation property"""
 
     # pylint: disable=redefined-outer-name
-
+    path = quote("Cars('Hadraplan')")
     responses.add(
         responses.GET,
-        f"{service.url}/Cars('Hadraplan')",
+        f"{service.url}/{path}",
         headers={'Content-type': 'application/json'},
         json = { 'd': {
             'Name': 'Hadraplan',
@@ -1121,7 +1137,7 @@ def test_navigation_1on1_from_entity_proxy(service):
 
     responses.add(
         responses.GET,
-        f"{service.url}/Cars('Hadraplan')/IDPic",
+        f"{service.url}/{path}/IDPic",
         headers={'Content-type': 'application/json'},
         json = { 'd': {
             'CarName': 'Hadraplan',
@@ -1153,10 +1169,10 @@ def test_navigation_1on1_get_value_without_proxy(service):
     """Check getting $value via navigation property"""
 
     # pylint: disable=redefined-outer-name
-
+    path = quote("Cars('Hadraplan')")
     responses.add(
         responses.GET,
-        f"{service.url}/Cars('Hadraplan')/IDPic/$value/",
+        f"{service.url}/{path}/IDPic/$value/",
         headers={'Content-type': 'application/jpeg'},
         body='DEADBEAF',
         status=200)
@@ -1175,10 +1191,10 @@ def test_navigation_when_nes_in_another_ns(service):
    """
 
     # pylint: disable=redefined-outer-name
-
+    path = quote("Customers('Mammon')/Orders")
     responses.add(
         responses.GET,
-        f"{service.url}/Customers('Mammon')/Orders",
+        f"{service.url}/{path}",
         json={'d': {'results' : [{
             'Number': '456',
             'Owner': 'Mammon',
@@ -1202,10 +1218,10 @@ def test_entity_get_value_1on1_with_proxy(service):
     """Check getting $value"""
 
     # pylint: disable=redefined-outer-name
-
+    path = quote("Cars('Hadraplan')")
     responses.add(
         responses.GET,
-        f"{service.url}/Cars('Hadraplan')/IDPic",
+        f"{service.url}/{path}/IDPic",
         headers={'Content-type': 'application/json'},
         json = { 'd': {
             'CarName': 'Hadraplan',
@@ -1216,7 +1232,7 @@ def test_entity_get_value_1on1_with_proxy(service):
 
     responses.add(
         responses.GET,
-        f"{service.url}/Cars('Hadraplan')/IDPic/$value/",
+        f"{service.url}/{path}/IDPic/$value/",
         headers={'Content-type': 'application/jpeg'},
         body='DEADBEAF',
         status=200)
@@ -1233,10 +1249,10 @@ def test_entity_get_value_without_proxy(service):
     """Check getting $value without proxy"""
 
     # pylint: disable=redefined-outer-name
-
+    path = quote("CarIDPics('Hadraplan')")
     responses.add(
         responses.GET,
-        f"{service.url}/CarIDPics('Hadraplan')/$value/",
+        f"{service.url}/{path}/$value/",
         headers={'Content-type': 'application/jpeg'},
         body='DEADBEAF',
         status=200)
@@ -1253,10 +1269,10 @@ def test_entity_get_value_with_proxy(service):
     """Check getting $value with proxy"""
 
     # pylint: disable=redefined-outer-name
-
+    path = quote("CarIDPics('Hadraplan')")
     responses.add(
         responses.GET,
-        f"{service.url}/CarIDPics('Hadraplan')",
+        f"{service.url}/{path}",
         headers={'Content-type': 'application/json'},
         json = { 'd': {
             'CarName': 'Hadraplan',
@@ -1267,7 +1283,7 @@ def test_entity_get_value_with_proxy(service):
 
     responses.add(
         responses.GET,
-        f"{service.url}/CarIDPics('Hadraplan')/$value/",
+        f"{service.url}/{path}/$value/",
         headers={'Content-type': 'application/jpeg'},
         body='DEADBEAF',
         status=200)
@@ -1284,10 +1300,10 @@ def test_entity_get_value_without_proxy_error(service):
     """Check getting $value without proxy"""
 
     # pylint: disable=redefined-outer-name
-
+    path = quote("CarIDPics('Hadraplan')")
     responses.add(
         responses.GET,
-        f"{service.url}/CarIDPics('Hadraplan')/$value/",
+        f"{service.url}/{path}/$value/",
         headers={'Content-type': 'text/plain'},
         body='Internal Server Error',
         status=500)
@@ -1334,10 +1350,10 @@ def test_navigation_from_entity_multi(service):
     """Get entities via navigation property from entity proxy"""
 
     # pylint: disable=redefined-outer-name
-
+    path = quote("Employees(23)")
     responses.add(
         responses.GET,
-        f"{service.url}/Employees(23)",
+        f"{service.url}/{path}",
         json={'d': {
             'ID': 23,
             'NameFirst': 'Rob',
@@ -1347,7 +1363,7 @@ def test_navigation_from_entity_multi(service):
 
     responses.add(
         responses.GET,
-        f"{service.url}/Employees(23)/Addresses",
+        f"{service.url}/{path}/Addresses",
         json={'d': {
             'results': [
                 {
@@ -1394,10 +1410,10 @@ def test_navigation_from_entity(service):
     """Check getting entity via navigation property from entity proxy"""
 
     # pylint: disable=redefined-outer-name
-
+    path_employes = quote("Employees(23)")
     responses.add(
         responses.GET,
-        f"{service.url}/Employees(23)",
+        f"{service.url}/{path_employes}",
         json={'d': {
             'ID': 23,
             'NameFirst': 'Rob',
@@ -1405,9 +1421,10 @@ def test_navigation_from_entity(service):
         }},
         status=200)
 
+    path_employes_adresses = quote("Employees(23)/Addresses(456)")
     responses.add(
         responses.GET,
-        f"{service.url}/Employees(23)/Addresses(456)",
+        f"{service.url}/{path_employes_adresses}",
         json={'d': {
             'ID': 456,
             'Street': 'Baker Street',
@@ -1437,10 +1454,10 @@ def test_get_entity(service):
     """Check getting entities"""
 
     # pylint: disable=redefined-outer-name
-
+    path = quote("Employees(23)")
     responses.add(
         responses.GET,
-        f"{service.url}/Employees(23)",
+        f"{service.url}/{path}",
         json={'d': {
             'ID': 23,
             'NameFirst': 'Rob',
@@ -1458,14 +1475,14 @@ def test_get_entity(service):
     assert emp.NameLast == 'Ickes'
 
 @responses.activate
-def test_get_entity_with_encoded_path(service):
+def test_get_entity_with_decoded_path(service):
     """Check getting entities"""
 
     # pylint: disable=redefined-outer-name
 
     responses.add(
         responses.GET,
-        f"{service.url}/TemperatureMeasurements%28Sensor%3D%27sensor1%27%2CDate%3Ddatetime%272017-12-24T18%3A00%3A00%27%29",
+        f"{service.url}/TemperatureMeasurements(Sensor='sensor1',Date=datetime'2017-12-24T18:00:00')",
         json={'d': {
             'Sensor': 'sensor1',
             'Date': '/Date(1514138400000)/',
@@ -1473,10 +1490,10 @@ def test_get_entity_with_encoded_path(service):
         }},
         status=200)
 
-    request = service.entity_sets.TemperatureMeasurements.get_entity(Sensor='sensor1', Date=datetime.datetime(2017, 12, 24, 18, 0, tzinfo=datetime.timezone.utc), encode_path=True)
+    request = service.entity_sets.TemperatureMeasurements.get_entity(Sensor='sensor1', Date=datetime.datetime(2017, 12, 24, 18, 0, tzinfo=datetime.timezone.utc), encode_path=False)
 
     assert isinstance(request, pyodata.v2.service.EntityGetRequest)
-    assert request.get_path() == 'TemperatureMeasurements%28Sensor%3D%27sensor1%27%2CDate%3Ddatetime%272017-12-24T18%3A00%3A00%27%29'
+    assert request.get_path() == "TemperatureMeasurements(Sensor='sensor1',Date=datetime'2017-12-24T18:00:00')"
 
     emp = request.execute()
     assert emp.Sensor == 'sensor1'
@@ -1489,10 +1506,10 @@ def test_get_entity_expanded(service):
     """Check getting entities with expanded navigation properties"""
 
     # pylint: disable=redefined-outer-name
-
+    path = quote("Employees(23)")
     responses.add(
         responses.GET,
-        f"{service.url}/Employees(23)",
+        f"{service.url}/{path}",
         json={'d': {
             'ID': 23,
             'NameFirst': 'Rob',
@@ -1590,7 +1607,7 @@ def test_batch_request(service):
     assert chset_response[0] is None   # response to update request is None
 
 @responses.activate
-def test_batch_request_with_encoded_path(service):
+def test_batch_request_with_decoded_path(service):
     """Batch requests"""
 
     # pylint: disable=redefined-outer-name
@@ -1631,9 +1648,9 @@ def test_batch_request_with_encoded_path(service):
 
     chset = service.create_changeset('chset1')
 
-    employee_request = service.entity_sets.Employees.get_entity(23, encode_path=True)
+    employee_request = service.entity_sets.Employees.get_entity(23, encode_path=False)
 
-    assert employee_request.get_path() == 'Employees%2823%29'
+    assert employee_request.get_path() == 'Employees(23)'
 
     temp_request = service.entity_sets.TemperatureMeasurements.update_entity(
         Sensor='sensor1',
@@ -1743,7 +1760,7 @@ def test_get_entity_with_entity_key(service):
         Date=datetime.datetime(2017, 12, 24, 18, 0, tzinfo=datetime.timezone.utc))
 
     query = service.entity_sets.TemperatureMeasurements.get_entity(key)
-    assert query.get_path() == "TemperatureMeasurements(Sensor='sensor1',Date=datetime'2017-12-24T18:00:00')"
+    assert query.get_path() == quote("TemperatureMeasurements(Sensor='sensor1',Date=datetime'2017-12-24T18:00:00')")
 
 
 def test_get_entity_with_entity_key_and_other_params(service):
@@ -1757,7 +1774,7 @@ def test_get_entity_with_entity_key_and_other_params(service):
         Date=datetime.datetime(2017, 12, 24, 18, 0, tzinfo=datetime.timezone.utc))
 
     query = service.entity_sets.TemperatureMeasurements.get_entity(key=key, Foo='Bar')
-    assert query.get_path() == "TemperatureMeasurements(Sensor='sensor1',Date=datetime'2017-12-24T18:00:00')"
+    assert query.get_path() == quote("TemperatureMeasurements(Sensor='sensor1',Date=datetime'2017-12-24T18:00:00')")
 
 
 def test_entity_proxy_equals(service):
@@ -1973,10 +1990,10 @@ def test_navigation_inlinecount(service):
     """Check getting entities with $inlinecount via navigation property"""
 
     # pylint: disable=redefined-outer-name
-
+    path = quote("Employees(23)/Addresses")
     responses.add(
         responses.GET,
-        f"{service.url}/Employees(23)/Addresses?$inlinecount=allpages",
+        f"{service.url}/{path}?$inlinecount=allpages",
         json={'d': {
             '__count': 3,
             'results': [
@@ -2010,10 +2027,10 @@ def test_inlinecount_with_filter(service):
     """Check getting entities with $inlinecount and $filter"""
 
     # pylint: disable=redefined-outer-name
-
+    path = quote("Employees(23)/Addresses")
     responses.add(
         responses.GET,
-        f"{service.url}/Employees(23)/Addresses?$inlinecount=allpages&%24filter=City%20eq%20%27London%27",
+        f"{service.url}/{path}?$inlinecount=allpages&%24filter=City%20eq%20%27London%27",
         json={'d': {
             '__count': 2,
             'results': [
@@ -2121,9 +2138,10 @@ def test_navigation_count(service):
 
     # pylint: disable=redefined-outer-name
 
+    path = quote("Employees(23)/Addresses")
     responses.add(
         responses.GET,
-        f"{service.url}/Employees(23)/Addresses/$count",
+        f"{service.url}/{path}/$count",
         json=458,
         status=200)
 
@@ -2140,10 +2158,10 @@ def test_count_with_filter(service):
     """Check getting $count with $filter"""
 
     # pylint: disable=redefined-outer-name
-
+    path = quote("Employees(23)/Addresses")
     responses.add(
         responses.GET,
-        f"{service.url}/Employees(23)/Addresses/$count?%24filter=City%20eq%20%27London%27",
+        f"{service.url}/{path}/$count?%24filter=City%20eq%20%27London%27",
         json=3,
         status=200)
 
@@ -2160,10 +2178,10 @@ def test_count_with_chainable_filter(service):
     """Check getting $count with $filter and using new filter syntax"""
 
     # pylint: disable=redefined-outer-name
-
+    path = quote("Employees(23)/Addresses")
     responses.add(
         responses.GET,
-        f"{service.url}/Employees(23)/Addresses/$count?%24filter=City%20eq%20%27London%27",
+        f"{service.url}/{path}/$count?%24filter=City%20eq%20%27London%27",
         json=3,
         status=200)
 
@@ -2793,9 +2811,10 @@ def test_odata_http_response():
 def test_custom_with_get_entity(service):
     """ Test that `custom` can be called after `get_entity`"""
 
+    path = quote("MasterEntities('12345')")
     responses.add(
         responses.GET,
-        f"{service.url}/MasterEntities('12345')?foo=bar",
+        f"{service.url}/{path}?foo=bar",
         headers={'Content-type': 'application/json'},
         json={'d': {'Key': '12345'}},
         status=200)
@@ -2807,16 +2826,17 @@ def test_custom_with_get_entity(service):
 def test_custom_with_get_entity_url_params(service):
     """ Test that `custom` after `get_entity` is setting up correctly URL parts """
 
+    path = quote("MasterEntities('12345')")
     responses.add(
         responses.GET,
-        f"{service.url}/MasterEntities('12345')?foo=bar",
+        f"{service.url}/{path}?foo=bar",
         headers={'Content-type': 'application/json'},
         json={'d': {'Key': '12345'}},
         status=200)
 
     oDataHttpRequest = service.entity_sets.MasterEntities.get_entity('12345').custom("foo", "bar")
     assert oDataHttpRequest.get_query_params() == {'foo': 'bar'}
-    assert oDataHttpRequest.get_path() == "MasterEntities('12345')"
+    assert oDataHttpRequest.get_path() == quote("MasterEntities('12345')")
 
     entity = oDataHttpRequest.execute()
     assert entity.Key == '12345'
@@ -2825,16 +2845,17 @@ def test_custom_with_get_entity_url_params(service):
 def test_multiple_custom_with_get_entity_url_params(service):
     """ Test that `custom` after `get_entity` called several times is setting up correctly URL parts """
 
+    path = quote("MasterEntities('12345')")
     responses.add(
         responses.GET,
-        f"{service.url}/MasterEntities('12345')?foo=bar&$fizz=buzz",
+        f"{service.url}/{path}?foo=bar&$fizz=buzz",
         headers={'Content-type': 'application/json'},
         json={'d': {'Key': '12345'}},
         status=200)
 
     oDataHttpRequest = service.entity_sets.MasterEntities.get_entity('12345').custom("foo", "bar").custom("$fizz", "buzz")
     assert oDataHttpRequest.get_query_params() == {'foo': 'bar', '$fizz': 'buzz'}
-    assert oDataHttpRequest.get_path() == "MasterEntities('12345')"
+    assert oDataHttpRequest.get_path() == quote("MasterEntities('12345')")
 
     entity = oDataHttpRequest.execute()
     assert entity.Key == '12345'

--- a/tests/test_service_v2.py
+++ b/tests/test_service_v2.py
@@ -658,7 +658,7 @@ def test_delete_entity(service):
     assert request.execute() is None
 
 @responses.activate
-def test_delete_entity_with_decoded_path(service):
+def test_delete_entity_not_encoded_path(service):
     """Check deleting of entity"""
 
     responses.add(responses.DELETE, f"{service.url}/Employees(23)", status=204)
@@ -1475,7 +1475,7 @@ def test_get_entity(service):
     assert emp.NameLast == 'Ickes'
 
 @responses.activate
-def test_get_entity_with_decoded_path(service):
+def test_get_entity_not_encoded_path(service):
     """Check getting entities"""
 
     # pylint: disable=redefined-outer-name
@@ -1607,7 +1607,7 @@ def test_batch_request(service):
     assert chset_response[0] is None   # response to update request is None
 
 @responses.activate
-def test_batch_request_with_decoded_path(service):
+def test_batch_request_not_encoded_path(service):
     """Batch requests"""
 
     # pylint: disable=redefined-outer-name

--- a/tests/test_service_v2.py
+++ b/tests/test_service_v2.py
@@ -1232,7 +1232,7 @@ def test_entity_get_value_1on1_with_proxy(service):
 
     responses.add(
         responses.GET,
-        f"{service.url}/{path}/IDPic/$value/",
+        f"{service.url}/Cars('Hadraplan')/IDPic/$value/",
         headers={'Content-type': 'application/jpeg'},
         body='DEADBEAF',
         status=200)
@@ -1283,7 +1283,7 @@ def test_entity_get_value_with_proxy(service):
 
     responses.add(
         responses.GET,
-        f"{service.url}/{path}/$value/",
+        f"{service.url}/CarIDPics('Hadraplan')/$value/",
         headers={'Content-type': 'application/jpeg'},
         body='DEADBEAF',
         status=200)


### PR DESCRIPTION
Sometimes services expect the path to be percent encoded. This can especially be important 
when special variable types are key fields like Date type, where a ':' will appear in the path. 
In this case you can use an optional parameter to make the request encode the path.
Per default the variable encode_path is set to False.