### PR TITLE
ci: use python 3.10.10 for linter job

### DIFF
--- a/.github/workflows/python-linters.yml
+++ b/.github/workflows/python-linters.yml
@@ -16,7 +16,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.10.1"]
+        python-version: ["3.10.10"]
         lxml-version: ["4.9.1"]
 
     steps:


### PR DESCRIPTION
Bump to latest stable bugfix version of Py3.10 

PR jobs did not run for a long time and 3.10.1 image is no longer available for "platform_version": "22.04",