### PR TITLE
tests: fix failures from bump of transitive deps to urllib3 2.X

### DIFF
--- a/tests/test_service_v2.py
+++ b/tests/test_service_v2.py
@@ -464,27 +464,6 @@ def test_function_import_without_return_type_wrong_code(mock_warning, service):
 
 
 @responses.activate
-@patch('logging.Logger.warning')
-def test_function_import_without_return_type_wrong_code(mock_warning, service):
-    """A simple function call without return type should not return any data"""
-
-    # pylint: disable=redefined-outer-name
-
-    responses.add(
-        responses.GET,
-        f"{service.url}/refresh",
-        body=b'unexpected',
-        status=204)
-
-    result = service.functions.refresh.execute()
-    assert result is None
-
-    mock_warning.assert_called_with(
-        'The No Return Function Import %s has returned content:\n%s',
-        'refresh', 'unexpected')
-
-
-@responses.activate
 def test_function_import_http_redirect(service):
     """Function Imports do not support Redirects"""
 
@@ -618,11 +597,6 @@ def test_update_entity(service):
     responses.add(
         responses.PATCH,
         f"{service.url}/{path}",
-        json={'d': {
-            'Sensor': 'Sensor-address',
-            'Date': "/Date(1714138400000)/",
-            'Value': '34.0d'
-        }},
         status=204)
 
     request = service.entity_sets.TemperatureMeasurements.update_entity(


### PR DESCRIPTION
- remove remove test_function_import_without_return_type_wrong_code

The entire logic of the test was based on scenario that server returns response of HTTP 204 No Content (which ends with HTTP Header) with some content in HTTP Body, which is breaking the HTTP protocol logic itself.

The Responses package generated such weird simulated response and was parsed with urllib 1.X in previous versions of Requests, but now, with being compatible with urllib3 2.x, breaking changes were introduced within this transitive dependency.

On the requests side, the bump to same urllib3 2.x means test failures with error:

requests.exceptions.ChunkedEncodingError: ('Connection broken: IncompleteRead(10 bytes read, -10 more expected)', IncompleteRead(10 bytes read, -10 more expected))

- test_update_entity

Same rationale, removed invalid body for expected HTTP 204 simulated response

Additional info:

getsentry/responses#636
https://urllib3.readthedocs.io/en/latest/v2-migration-guide.html

RFC 2616  - HTTP 1.1 - 10.2.5 - 204 No Content
https://datatracker.ietf.org/doc/html/rfc2616#section-10.2.5