### PR TITLE
Fix adding expanded entities to EntityProxy

### DIFF
--- a/pyodata/v2/service.py
+++ b/pyodata/v2/service.py
@@ -873,9 +873,11 @@ class EntityProxy:
                         # if there are no entities available, received data consists of
                         # metadata properties only.
                         if 'results' in proprties[prop.name]:
-
                             # available entities are serialized in results array
                             for entity in proprties[prop.name]['results']:
+                                self._cache[prop.name].append(EntityProxy(service, None, prop_etype, entity))
+                        else:
+                            for entity in proprties[prop.name]:
                                 self._cache[prop.name].append(EntityProxy(service, None, prop_etype, entity))
                     else:
                         raise PyODataException('Unknown multiplicity {0} of association role {1}'

--- a/tests/test_service_v2.py
+++ b/tests/test_service_v2.py
@@ -1476,7 +1476,7 @@ def test_get_entity_not_encoded_path(service):
 
 
 @responses.activate
-def test_get_entity_expanded(service):
+def test_get_entity_expanded_with_results(service):
     """Check getting entities with expanded navigation properties"""
 
     # pylint: disable=redefined-outer-name
@@ -1513,6 +1513,42 @@ def test_get_entity_expanded(service):
     assert emp.Addresses[0].Street == 'Baker Street'
     assert emp.Addresses[0].City == 'London'
 
+@responses.activate
+def test_get_entity_expanded(service):
+    """Check getting entities with expanded navigation properties"""
+
+    # pylint: disable=redefined-outer-name
+    path = quote("Employees(23)")
+    responses.add(
+        responses.GET,
+        f"{service.url}/{path}",
+        json={'d': {
+            'ID': 23,
+            'NameFirst': 'Rob',
+            'NameLast': 'Ickes',
+            'Addresses': [
+                    {
+                        'ID': 456,
+                        'Street': 'Baker Street',
+                        'City': 'London'
+                    }
+                ]
+            
+        }},
+        status=200)
+
+    request = service.entity_sets.Employees.get_entity(23)
+    assert isinstance(request, pyodata.v2.service.EntityGetRequest)
+
+    emp = request.expand('Addresses').execute()
+
+    assert emp.ID == 23
+    assert emp.NameFirst == 'Rob'
+    assert emp.NameLast == 'Ickes'
+
+    assert emp.Addresses[0].ID == 456
+    assert emp.Addresses[0].Street == 'Baker Street'
+    assert emp.Addresses[0].City == 'London'
 
 @responses.activate
 def test_batch_request(service):


### PR DESCRIPTION
EntityProxy expected expanded properties to be wrapped in a 'results' object, which isn't to V2 JSON spec. This fix removes this expectation. The original behavior is not removed, so if there happens to be an expanded property wrapped in a 'results' object, EntityProxy continues to work as before.

Fixes #258