### PR TITLE
ci: setup compatibility runs also weekly

### DIFF
--- a/.github/workflows/python-tests-compatibility.yml
+++ b/.github/workflows/python-tests-compatibility.yml
@@ -8,6 +8,8 @@ on:
     branches: [ master ]
   pull_request:
     branches: [ master ]
+  schedule: 
+    - cron: '0 0 * * SUN'    
 
 jobs:
   build:


### PR DESCRIPTION
Because CI for package compatibility are a intentionally a "moving target" for package updates, it is not enough to depend on running just after commit to master.

When long time pass, build is often broken due compatibility changes irrelevant to actual code change. So this change is intended to at least spot problems before such situation and ease debugging of CI.