### PR TITLE
chore: bumps in dev-requirements.txt

### DIFF
--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -10,4 +10,4 @@ pylint==2.8.3
 pytest-cov>=3.0.0
 flake8==3.8.4
 bandit==1.7.5
-sphinx==7.3.7
+sphinx

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -9,5 +9,5 @@ setuptools-scm>=1.15.6
 pylint==2.8.3
 pytest-cov>=3.0.0
 flake8==3.8.4
-bandit==1.7.0
-sphinx
+bandit==1.7.5
+sphinx==7.3.7


### PR DESCRIPTION
- bump bandit to latest that support python 3.7 
- set version for sphinx