### PR TITLE
Escape slashes in entity keys when they appear in the URL path

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 ### Fixed
-- Escape slashes in entity keys when they appear in the URL path
+- Escape slashes in entity keys when they appear in the URL path - Jon Friesen
 
 ### Removed
 - Python 3.7 (long after its EOL) is no longer supported by pyodata. Python 3.8 is now minimal supported version. - Petr Hanak

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
-
+### Fixed
+- Escape slashes in entity keys when they appear in the URL path
 
 ### Removed
 - Python 3.7 (long after its EOL) is no longer supported by pyodata. Python 3.8 is now minimal supported version. - Petr Hanak

--- a/pyodata/v2/service.py
+++ b/pyodata/v2/service.py
@@ -405,7 +405,7 @@ class EntityGetRequest(ODataHttpRequest):
 
     def get_path(self):
         if self.get_encode_path():
-            return quote(self._entity_set_proxy.last_segment + self._entity_key.to_key_string())
+            return quote(self._entity_set_proxy.last_segment) + quote(self._entity_key.to_key_string(), safe='')
         return self._entity_set_proxy.last_segment + self._entity_key.to_key_string()
 
     def get_default_headers(self):
@@ -563,7 +563,7 @@ class EntityDeleteRequest(ODataHttpRequest):
 
     def get_path(self):
         if self.get_encode_path():
-            return quote(self._entity_set.name + self._entity_key.to_key_string())
+            return quote(self._entity_set.name) + quote(self._entity_key.to_key_string(), safe='')
         return self._entity_set.name + self._entity_key.to_key_string()
 
     def get_encode_path(self):
@@ -607,7 +607,7 @@ class EntityModifyRequest(ODataHttpRequest):
 
     def get_path(self):
         if self.get_encode_path():
-            return quote(self._entity_set.name + self._entity_key.to_key_string())
+            return quote(self._entity_set.name) + quote(self._entity_key.to_key_string(), safe='')
         return self._entity_set.name + self._entity_key.to_key_string()
 
     def get_method(self):

--- a/tests/test_service_v2.py
+++ b/tests/test_service_v2.py
@@ -243,6 +243,22 @@ def test_entity_url(service):
     entity = service.entity_sets.MasterEntities.get_entity('12345').execute()
     assert entity.url == URL_ROOT + "/MasterEntities('12345')"
 
+@responses.activate
+def test_entity_url_with_slashes(service):
+    """Test correct build of entity url"""
+
+    # pylint: disable=redefined-outer-name
+    path = quote("MasterEntities('FOO/BAR')", safe='')
+    responses.add(
+        responses.GET,
+        f"{service.url}/{path}",
+        headers={'Content-type': 'application/json'},
+        json={'d': {'Key': 'FOO/BAR'}},
+        status=200)
+
+    entity = service.entity_sets.MasterEntities.get_entity('FOO/BAR').execute()
+    assert entity.url == URL_ROOT + "/MasterEntities('FOO/BAR')"
+
 
 @responses.activate
 def test_entity_entity_set_name(service):
@@ -630,6 +646,7 @@ def test_delete_entity(service):
 
     assert isinstance(request, pyodata.v2.service.EntityDeleteRequest)
     assert request.execute() is None
+
 
 @responses.activate
 def test_delete_entity_not_encoded_path(service):


### PR DESCRIPTION
Pyodata does not correctly escape the path when an entity key contains a /. This minor correction quotes the entity key with `safe=""` to ensure slashes are quoted.  The rest of the path is quoted with the default (`safe='/') so that path delimiters are not quoted.

Closes #282 