### PR TITLE
chore: drop Python 3.9 support, raise minimum to 3.10

### DIFF
--- a/.github/workflows/python-tests-compatibility.yml
+++ b/.github/workflows/python-tests-compatibility.yml
@@ -18,15 +18,9 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.9", "3.10", "3.11", "3.12", "3.13", "3.14"]
-        lxml-version: ["4.3.5", "4.4.3", "4.5.2", "4.6.5", "4.7.1", "4.8.0", "4.9.4", "5.0.1", "5.1.1", "5.2.2", "5.3.2", "5.4.0", "6.0.2"]
+        python-version: ["3.10", "3.11", "3.12", "3.13", "3.14"]
+        lxml-version: ["4.6.5", "4.7.1", "4.8.0", "4.9.4", "5.0.1", "5.1.1", "5.2.2", "5.3.2", "5.4.0", "6.0.2"]
         exclude:
-          - python-version: 3.10
-            lxml-version: 4.3.5
-          - python-version: 3.10
-            lxml-version: 4.4.3
-          - python-version: 3.10
-            lxml-version: 4.5.2
           - python-version: 3.11
             lxml-version: 4.3.5
           - python-version: 3.11

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - service: let FunctionRequests return a list of EntityProxies instead of the raw json, when the `ReturnType` is a Collection. - Emil B.
 - model: replace regexp-based ISO datetime parsing with `datetime.fromisoformat` for `Edm.DateTime` and `Edm.DateTimeOffset` - Petr Hanak
 
+### Removed
+- Python 3.9 is no longer supported by pyodata. Python 3.10 is now the minimal supported version.
+
 ## [1.11.2]
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ details.
 
 ## Requirements
 
-- [Python >= 3.9](https://www.python.org/downloads/)
+- [Python >= 3.10](https://www.python.org/downloads/)
 
 ## Download and Installation
 

--- a/setup.py
+++ b/setup.py
@@ -36,6 +36,7 @@ setup(
     long_description_content_type="text/markdown",
     packages=find_packages(exclude=("tests")),
     zip_safe=False,
+    python_requires='>=3.10',
     install_requires=[
         "lxml>=4.2.6",
     ],
@@ -59,7 +60,6 @@ setup(
         'Intended Audience :: Developers',
         'License :: OSI Approved :: Apache Software License',
         'Operating System :: OS Independent',
-        'Programming Language :: Python :: 3.9',
         'Programming Language :: Python :: 3.10',
         'Programming Language :: Python :: 3.11',
         'Programming Language :: Python :: 3.12',

--- a/tests/test_vendor_sap.py
+++ b/tests/test_vendor_sap.py
@@ -1,7 +1,7 @@
 """PyOData Vendor SAP tests"""
 
 import logging
-from typing import NamedTuple, ByteString
+from typing import NamedTuple
 import pytest
 from pyodata.exceptions import PyODataException, HttpError
 from pyodata.vendor import SAP
@@ -11,7 +11,7 @@ import json
 
 
 class MockResponse(NamedTuple):
-    content: ByteString
+    content: bytes
 
 
 @pytest.fixture


### PR DESCRIPTION
- Remove 3.9 from CI matrix; drop lxml 4.3.5/4.4.3/4.5.2 (3.9-only) and their now-redundant 3.10 excludes
- Add python_requires='>=3.10' to setup.py; remove 3.9 classifier
- Update README requirement from 3.9 to 3.10
- Add CHANGELOG Removed entry for 3.9 drop
- Replace deprecated typing.ByteString with bytes in test_vendor_sap.py