### PR TITLE
tests: fix failing test in MockHeaderResponse

### DIFF
--- a/tests/test_vendor_sap.py
+++ b/tests/test_vendor_sap.py
@@ -275,7 +275,7 @@ def test_add_btp_token_to_session_invalid_clientid():
 
 class MockHeaderResponse(NamedTuple):
     headers: dict
-    content: ByteString = b''
+    content: bytes = b''
     status_code: int = 200
 
 


### PR DESCRIPTION
bytes is the correct concrete type for the content field and matches the b'' default value.