### PR TITLE
ci: update lxml compatibility matrix

### DIFF
--- a/.github/workflows/python-tests-compatibility.yml
+++ b/.github/workflows/python-tests-compatibility.yml
@@ -19,14 +19,8 @@ jobs:
       fail-fast: false
       matrix:
         python-version: ["3.10", "3.11", "3.12", "3.13", "3.14"]
-        lxml-version: ["4.6.5", "4.7.1", "4.8.0", "4.9.4", "5.0.1", "5.1.1", "5.2.2", "5.3.2", "5.4.0", "6.0.2"]
+        lxml-version: ["4.6.5", "4.7.1", "4.8.0", "4.9.4", "5.0.1", "5.1.1", "5.2.2", "5.3.2", "5.4.0", "6.0.4", "6.1.1"]
         exclude:
-          - python-version: 3.11
-            lxml-version: 4.3.5
-          - python-version: 3.11
-            lxml-version: 4.4.3
-          - python-version: 3.11
-            lxml-version: 4.5.2
           - python-version: 3.11
             lxml-version: 4.6.5
           - python-version: 3.11
@@ -34,14 +28,6 @@ jobs:
           - python-version: 3.11
             lxml-version: 4.8.0 
           - python-version: 3.12
-            lxml-version: 4.3.5           
-          - python-version: 3.12
-            lxml-version: 4.4.3
-          - python-version: 3.12
-            lxml-version: 4.4.3          
-          - python-version: 3.12
-            lxml-version: 4.5.2
-          - python-version: 3.12
             lxml-version: 4.6.5
           - python-version: 3.12
             lxml-version: 4.7.1  
@@ -50,14 +36,6 @@ jobs:
           - python-version: 3.12
             lxml-version: 4.9.4
           - python-version: 3.13
-            lxml-version: 4.3.5           
-          - python-version: 3.13
-            lxml-version: 4.4.3
-          - python-version: 3.13
-            lxml-version: 4.4.3          
-          - python-version: 3.13
-            lxml-version: 4.5.2
-          - python-version: 3.13
             lxml-version: 4.6.5
           - python-version: 3.13
             lxml-version: 4.7.1  
@@ -65,14 +43,6 @@ jobs:
             lxml-version: 4.8.0  
           - python-version: 3.13
             lxml-version: 4.9.4
-          - python-version: 3.14
-            lxml-version: 4.3.5           
-          - python-version: 3.14
-            lxml-version: 4.4.3
-          - python-version: 3.14
-            lxml-version: 4.4.3          
-          - python-version: 3.14
-            lxml-version: 4.5.2
           - python-version: 3.14
             lxml-version: 4.6.5
           - python-version: 3.14


### PR DESCRIPTION
- add latest 6.0.X and 6.1.X to compatibility testing
- remove unnecessary excludes that were relevant to python 3.9